### PR TITLE
Add support for persona skype presence icons

### DIFF
--- a/src/documentation/pages/Persona/examples/PersonaExampleProps.js
+++ b/src/documentation/pages/Persona/examples/PersonaExampleProps.js
@@ -3,14 +3,14 @@ var PersonaExampleProps = {
     "image": "Persona.Person2.png",
     "primaryText": "Alton Lafferty",
     "secondaryText": "Accountant",
-    "icon": "skypeCheck"
+    "icon": "SkypeCheck"
   },
   "large": {
     "image": "Persona.Person2.png",
     "primaryText": "Alton Lafferty",
     "secondaryText": "Accountant",
     "tertiaryText": "In a meeting",
-    "icon": "skypeCheck",
+    "icon": "SkypeCheck",
     "modifiers": [
       {
         "name": "lg"
@@ -23,7 +23,7 @@ var PersonaExampleProps = {
     "secondaryText": "Accountant",
     "tertiaryText": "In a meeting",
     "optionalText": "Available at 4:00pm",
-    "icon": "skypeCheck",
+    "icon": "SkypeCheck",
     "modifiers":  [
       {
         "name": "xl"
@@ -34,7 +34,7 @@ var PersonaExampleProps = {
     "image": "Persona.Person2.png",
     "primaryText": "Alton Lafferty",
     "secondaryText": "Accountant",
-    "icon": "skypeCheck",
+    "icon": "SkypeCheck",
     "modifiers":  [
       {
         "name": "sm"
@@ -44,7 +44,7 @@ var PersonaExampleProps = {
   "extraSmall": {
     "image": "Persona.Person2.png",
     "primaryText": "Alton Lafferty",
-    "icon": "skypeCheck",
+    "icon": "SkypeCheck",
     "modifiers":  [
       {
         "name": "xs"
@@ -53,7 +53,7 @@ var PersonaExampleProps = {
   },
   "tiny": {
     "primaryText": "Alton Lafferty",
-    "icon": "skypeCheck",
+    "icon": "SkypeCheck",
     "modifiers":  [
       {
         "name": "tiny"
@@ -64,13 +64,13 @@ var PersonaExampleProps = {
     "initials": "AL",
     "initialsColor": "blue",
     "primaryText": "Alton Lafferty",
-    "icon": "skypeCheck"
+    "icon": "SkypeCheck"
   },
   "presenceAvailable": {
     "image": "Persona.Person2.png",
     "primaryText": "Alton Lafferty",
     "secondaryText": "Accountant",
-    "icon": "skypeCheck",
+    "icon": "SkypeCheck",
     "modifiers":  [
       {
         "name": "available"
@@ -81,7 +81,7 @@ var PersonaExampleProps = {
     "image": "Persona.Person2.png",
     "primaryText": "Alton Lafferty",
     "secondaryText": "Accountant",
-    "icon": "skypeClock",
+    "icon": "SkypeClock",
     "modifiers":  [
       {
         "name": "away"
@@ -112,7 +112,7 @@ var PersonaExampleProps = {
     "image": "Persona.Person2.png",
     "primaryText": "Alton Lafferty",
     "secondaryText": "Accountant",
-    "icon": "skypeMinus",
+    "icon": "SkypeMinus",
     "modifiers":  [
       {
         "name": "dnd"
@@ -133,7 +133,7 @@ var PersonaExampleProps = {
     "image": "Persona.Person2.png",
     "primaryText": "Gerrad Matteu",
     "actionIcon": "x",
-    "icon": "skypeCheck",
+    "icon": "SkypeCheck",
     "modifiers": [
       {
         "name": "token"

--- a/src/sass/Fabric.Icons.Output.scss
+++ b/src/sass/Fabric.Icons.Output.scss
@@ -304,6 +304,9 @@
 .ms-Icon--PageAdd::before { @include ms-Icon--PageAdd }
 .ms-Icon--NumberedList::before { @include ms-Icon--NumberedList }
 .ms-Icon--Glimmer::before { @include ms-Icon--Glimmer }
+.ms-Icon--SkypeCheck:before { @include ms-Icon--SkypeCheck }
+.ms-Icon--SkypeClock:before { @include ms-Icon--SkypeClock }
+.ms-Icon--SkypeMinus:before { @include ms-Icon--SkypeMinus }
 
 // Modifier: Place the icon in a circle.
 .ms-Icon--circle {

--- a/src/sass/_Fabric.Icons.scss
+++ b/src/sass/_Fabric.Icons.scss
@@ -309,6 +309,9 @@
 @mixin ms-Icon--PageAdd { content: "\EA1A"; }
 @mixin ms-Icon--NumberedList { content: "\EA1C"; }
 @mixin ms-Icon--Glimmer { content: "\ECF4"; }
+@mixin ms-Icon--SkypeCheck { content: "\EF80"; }
+@mixin ms-Icon--SkypeClock { content: "\EF81"; }
+@mixin ms-Icon--SkypeMinus { content: "\EF82"; }
 
 
 // Modifier: Place the icon in a circle.


### PR DESCRIPTION
Add support for skype icons, update persona example props with correct classes.

Note: Fabric icon font is in the process of being deployed to the CDN. This can be merged after the deployment is complete.
