### PR TITLE
Remove persona initials colors and align to Fabric accent colors

### DIFF
--- a/src/components/Persona/Persona.scss
+++ b/src/components/Persona/Persona.scss
@@ -100,7 +100,7 @@ $ms-Persona-presenceSizeXl: 28px;
   font-weight: $ms-font-weight-light;
   line-height: $ms-Persona-sizeMd;
 
-  &.ms-Persona-initials--lightBlue {
+  &.ms-Persona-initials--blueLight {
     background-color: $ms-color-blueLight;
   }
 
@@ -108,7 +108,7 @@ $ms-Persona-presenceSizeXl: 28px;
     background-color: $ms-color-blue;
   }
 
-  &.ms-Persona-initials--darkBlue {
+  &.ms-Persona-initials--blueDark {
     background-color: $ms-color-blueDark;
   }
 
@@ -116,7 +116,7 @@ $ms-Persona-presenceSizeXl: 28px;
     background-color: $ms-color-teal;
   }
 
-  &.ms-Persona-initials--lightGreen {
+  &.ms-Persona-initials--greenLight {
     background-color: $ms-color-greenLight;
   }
 
@@ -124,11 +124,11 @@ $ms-Persona-presenceSizeXl: 28px;
     background-color: $ms-color-green;
   }
 
-  &.ms-Persona-initials--darkGreen {
+  &.ms-Persona-initials--greenDark {
     background-color: $ms-color-greenDark;
   }
 
-  &.ms-Persona-initials--lightMagenta {
+  &.ms-Persona-initials--magentaLight {
     background-color: $ms-color-magentaLight;
   }
 
@@ -136,7 +136,7 @@ $ms-Persona-presenceSizeXl: 28px;
     background-color: $ms-color-magenta;
   }
 
-  &.ms-Persona-initials--lightPurple {
+  &.ms-Persona-initials--purpleLight {
     background-color: $ms-color-purpleLight;
   }
 
@@ -156,7 +156,7 @@ $ms-Persona-presenceSizeXl: 28px;
     background-color: $ms-color-red;
   }
 
-  &.ms-Persona-initials--darkRed {
+  &.ms-Persona-initials--redDark {
     background-color: $ms-color-redDark;
   }
 }

--- a/src/components/Persona/Persona.scss
+++ b/src/components/Persona/Persona.scss
@@ -6,23 +6,6 @@
 // Persona styles
 
 
-//= Colors used in the initials color block
-$ms-color-initials-lightBlue:   #6BA5E7;
-$ms-color-initials-blue:        #2D89EF;
-$ms-color-initials-darkBlue:    #2B5797;
-$ms-color-initials-teal:        #00ABA9;
-$ms-color-initials-lightGreen:  #99B433;
-$ms-color-initials-green:       #00A300;
-$ms-color-initials-darkGreen:   #1E7145;
-$ms-color-initials-lightPink:   #E773BD;
-$ms-color-initials-pink:        #FF0097;
-$ms-color-initials-magenta:     #7E3878;
-$ms-color-initials-purple:      #603CBA;
-$ms-color-initials-black:       #1D1D1D;
-$ms-color-initials-orange:      #DA532C;
-$ms-color-initials-red:         #EE1111;
-$ms-color-initials-darkRed:     #B91D47;
-
 // Skype presence colors
 $ms-color-presence-available:          #7FBA00;
 $ms-color-presence-away:               #FCD116;
@@ -118,63 +101,63 @@ $ms-Persona-presenceSizeXl: 28px;
   line-height: $ms-Persona-sizeMd;
 
   &.ms-Persona-initials--lightBlue {
-    background-color: $ms-color-initials-lightBlue;
+    background-color: $ms-color-blueLight;
   }
 
   &.ms-Persona-initials--blue {
-    background-color: $ms-color-initials-blue;
+    background-color: $ms-color-blue;
   }
 
   &.ms-Persona-initials--darkBlue {
-    background-color: $ms-color-initials-darkBlue;
+    background-color: $ms-color-blueDark;
   }
 
   &.ms-Persona-initials--teal {
-    background-color: $ms-color-initials-teal;
+    background-color: $ms-color-teal;
   }
 
   &.ms-Persona-initials--lightGreen {
-    background-color: $ms-color-initials-lightGreen;
+    background-color: $ms-color-greenLight;
   }
 
   &.ms-Persona-initials--green {
-    background-color: $ms-color-initials-green;
+    background-color: $ms-color-green;
   }
 
   &.ms-Persona-initials--darkGreen {
-    background-color: $ms-color-initials-darkGreen;
+    background-color: $ms-color-greenDark;
   }
 
-  &.ms-Persona-initials--lightPink {
-    background-color: $ms-color-initials-lightPink;
-  }
-
-  &.ms-Persona-initials--pink {
-    background-color: $ms-color-initials-pink;
+  &.ms-Persona-initials--lightMagenta {
+    background-color: $ms-color-magentaLight;
   }
 
   &.ms-Persona-initials--magenta {
-    background-color: $ms-color-initials-magenta;
+    background-color: $ms-color-magenta;
+  }
+
+  &.ms-Persona-initials--lightPurple {
+    background-color: $ms-color-purpleLight;
   }
 
   &.ms-Persona-initials--purple {
-    background-color: $ms-color-initials-purple;
+    background-color: $ms-color-purple;
   }
 
   &.ms-Persona-initials--black {
-    background-color: $ms-color-initials-black;
+    background-color: $ms-color-black;
   }
 
   &.ms-Persona-initials--orange {
-    background-color: $ms-color-initials-orange;
+    background-color: $ms-color-orange;
   }
 
   &.ms-Persona-initials--red {
-    background-color: $ms-color-initials-red;
+    background-color: $ms-color-red;
   }
 
   &.ms-Persona-initials--darkRed {
-    background-color: $ms-color-initials-darkRed;
+    background-color: $ms-color-redDark;
   }
 }
 


### PR DESCRIPTION
This removes the separate set of colors with persona.scss and instead uses the accent colors already in Fabric. Some class names needed to be updated to match the color variable names. 