### PR TITLE
Leddie24/component bug fixes

### DIFF
--- a/src/components/ContextualMenu/ContextualMenu.scss
+++ b/src/components/ContextualMenu/ContextualMenu.scss
@@ -13,6 +13,7 @@
   font-weight: $ms-font-weight-regular;
   display: block;
   min-width: 180px;
+  max-width: 220px;
   list-style-type: none;
   position: relative;
   background-color: $ms-color-white;
@@ -34,9 +35,12 @@
   cursor: pointer;
   display: block;
   height: 36px;
+  overflow: hidden;
   line-height: 34px;
   padding: 0 16px 0 25px;
   position: relative;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 
   &:hover,
   &:active,

--- a/src/components/DatePicker/DatePicker.hbs
+++ b/src/components/DatePicker/DatePicker.hbs
@@ -4,20 +4,20 @@
 <div class="ms-DatePicker">
   <div class="ms-TextField">
     <label class="ms-Label">Start date</label>
-    <i class="ms-DatePicker-event ms-Icon ms-Icon--event"></i>
+    <i class="ms-DatePicker-event ms-Icon ms-Icon--Event"></i>
     <input class="ms-TextField-field" type="text" placeholder="Select a date&hellip;">
   </div>
   <div class="ms-DatePicker-monthComponents">
-    <span class="ms-DatePicker-nextMonth js-nextMonth"><i class="ms-Icon ms-Icon--chevronRight"></i></span>
-    <span class="ms-DatePicker-prevMonth js-prevMonth"><i class="ms-Icon ms-Icon--chevronLeft"></i></span>
+    <span class="ms-DatePicker-nextMonth js-nextMonth"><i class="ms-Icon ms-Icon--ChevronRight"></i></span>
+    <span class="ms-DatePicker-prevMonth js-prevMonth"><i class="ms-Icon ms-Icon--ChevronLeft"></i></span>
     <div class="ms-DatePicker-headerToggleView js-showMonthPicker"></div>
   </div>
   <span class="ms-DatePicker-goToday js-goToday">Go to today</span>
   <div class="ms-DatePicker-monthPicker">
     <div class="ms-DatePicker-header">
       <div class="ms-DatePicker-yearComponents">
-        <span class="ms-DatePicker-nextYear js-nextYear"><i class="ms-Icon ms-Icon--chevronRight"></i></span>
-        <span class="ms-DatePicker-prevYear js-prevYear"><i class="ms-Icon ms-Icon--chevronLeft"></i></span>
+        <span class="ms-DatePicker-nextYear js-nextYear"><i class="ms-Icon ms-Icon--ChevronRight"></i></span>
+        <span class="ms-DatePicker-prevYear js-prevYear"><i class="ms-Icon ms-Icon--ChevronLeft"></i></span>
       </div>
       <div class="ms-DatePicker-currentYear js-showYearPicker"></div>
     </div>
@@ -38,8 +38,8 @@
   </div>
   <div class="ms-DatePicker-yearPicker">
     <div class="ms-DatePicker-decadeComponents">
-      <span class="ms-DatePicker-nextDecade js-nextDecade"><i class="ms-Icon ms-Icon--chevronRight"></i></span>
-      <span class="ms-DatePicker-prevDecade js-prevDecade"><i class="ms-Icon ms-Icon--chevronLeft"></i></span>
+      <span class="ms-DatePicker-nextDecade js-nextDecade"><i class="ms-Icon ms-Icon--ChevronRight"></i></span>
+      <span class="ms-DatePicker-prevDecade js-prevDecade"><i class="ms-Icon ms-Icon--ChevronLeft"></i></span>
     </div>
   </div>
 </div>

--- a/src/components/Dialog/Dialog.ts
+++ b/src/components/Dialog/Dialog.ts
@@ -27,7 +27,7 @@ namespace fabric {
     public close(): void {
       this._overlay.remove();
       this._dialog.classList.remove("is-open");
-      document.body.classList.remove("ms-noScroll");
+      document.body.classList.remove("ms-u-overflowHidden");
       this._overlay.overlayElement.removeEventListener("click", this.close.bind(this));
     }
 
@@ -37,7 +37,7 @@ namespace fabric {
       if (!this._dialog.classList.contains("ms-Dialog--blocking")) {
         this._overlay.overlayElement.addEventListener("click", this.close.bind(this), false);
         this._overlay.show();
-        document.body.classList.add("ms-noScroll");
+        document.body.classList.add("ms-u-overflowHidden");
       }
       this._dialog.parentElement.appendChild(this._overlay.overlayElement);
     }

--- a/src/components/Dialog/Dialog.ts
+++ b/src/components/Dialog/Dialog.ts
@@ -27,6 +27,7 @@ namespace fabric {
     public close(): void {
       this._overlay.remove();
       this._dialog.classList.remove("is-open");
+      document.body.classList.remove("ms-noScroll");
       this._overlay.overlayElement.removeEventListener("click", this.close.bind(this));
     }
 
@@ -36,6 +37,7 @@ namespace fabric {
       if (!this._dialog.classList.contains("ms-Dialog--blocking")) {
         this._overlay.overlayElement.addEventListener("click", this.close.bind(this), false);
         this._overlay.show();
+        document.body.classList.add("ms-noScroll");
       }
       this._dialog.parentElement.appendChild(this._overlay.overlayElement);
     }

--- a/src/components/Dropdown/Dropdown.scss
+++ b/src/components/Dropdown/Dropdown.scss
@@ -220,7 +220,6 @@
     background: $ms-color-white;
     color: $ms-color-neutralTertiary;
     cursor: default;
-    line-height: 40px;
   }
 }
 
@@ -231,7 +230,6 @@
 .ms-Dropdown-item.ms-Dropdown-item--selected {
   background-color: $ms-color-themeLight;
   color: $ms-color-black;
-  line-height: 40px;
 
   &:hover {
     background-color: $ms-color-themeLight;

--- a/src/components/FacePile/FacePile.hbs
+++ b/src/components/FacePile/FacePile.hbs
@@ -2,7 +2,7 @@
 
 <div class="ms-FacePile">
   <button class="ms-FacePile-addButton ms-FacePile-addButton--addPerson">
-    <i class="ms-FacePile-addPersonIcon ms-Icon ms-Icon--personAdd"></i>
+    <i class="ms-FacePile-addPersonIcon ms-Icon ms-Icon--AddFriend"></i>
   </button>
   
   {{#each props.members}}

--- a/src/components/ListItem/ListItem.hbs
+++ b/src/components/ListItem/ListItem.hbs
@@ -10,10 +10,10 @@
   <div class="ms-ListItem-selectionTarget"></div>
   <div class="ms-ListItem-actions">
     {{#each props.actions}}{{/each}}
-    <div class="ms-ListItem-action"><i class="ms-Icon ms-Icon--mail"></i></div>
-    <div class="ms-ListItem-action"><i class="ms-Icon ms-Icon--trash"></i></div>
-    <div class="ms-ListItem-action"><i class="ms-Icon ms-Icon--flag"></i></div>
-    <div class="ms-ListItem-action"><i class="ms-Icon ms-Icon--pinLeft"></i></div>
+    <div class="ms-ListItem-action"><i class="ms-Icon ms-Icon--Mail"></i></div>
+    <div class="ms-ListItem-action"><i class="ms-Icon ms-Icon--Delete"></i></div>
+    <div class="ms-ListItem-action"><i class="ms-Icon ms-Icon--Flag"></i></div>
+    <div class="ms-ListItem-action"><i class="ms-Icon ms-Icon--Pinned"></i></div>
   </div>
 </li>
 

--- a/src/components/ListItem/ListItem.scss
+++ b/src/components/ListItem/ListItem.scss
@@ -158,8 +158,8 @@
     &::before {
       @include ms-Icon;
       position: absolute;
-      top: 12px;
-      left: 6px;
+      top: 14px;
+      left: 7px;
       height: 15px;
       width: 15px;
       border: 1px solid $ms-color-neutralSecondaryAlt;
@@ -179,12 +179,13 @@
   &::before,
   &:hover::before {
     @include ms-Icon;
-    content: '\e041';
-    font-size: $ms-font-size-m-plus;
+    content: '\e73A';
+    font-size: $ms-font-size-l;
     color: $ms-color-neutralSecondaryAlt;
     position: absolute;
-    top: 12px;
-    left: 6px;
+    top: 23px;
+    left: 7px;
+    border: 0;
   }
 
   &:hover {

--- a/src/components/MessageBanner/MessageBanner.hbs
+++ b/src/components/MessageBanner/MessageBanner.hbs
@@ -8,13 +8,13 @@
       </div>
     </div>
     <button class="ms-MessageBanner-expand">
-      <i class="ms-Icon ms-Icon--chevronsDown"></i>
+      <i class="ms-Icon ms-Icon--ChevronDown"></i>
     </button>
     <div class="ms-MessageBanner-action">
       {{renderPartial props.button.name props.button.props}}
     </div>
   </div>
   <button class="ms-MessageBanner-close">
-    <i class="ms-Icon ms-Icon--x"></i>
+    <i class="ms-Icon ms-Icon--Clear"></i>
   </button>
 </div>

--- a/src/components/Overlay/Overlay.scss
+++ b/src/components/Overlay/Overlay.scss
@@ -27,3 +27,7 @@
 .ms-Overlay--dark {
   background-color: $ms-color-blackTranslucent40;
 }
+
+.ms-noScroll {
+  overflow: hidden;
+}

--- a/src/components/Overlay/Overlay.scss
+++ b/src/components/Overlay/Overlay.scss
@@ -9,7 +9,7 @@
 .ms-Overlay {
   @include ms-baseFont;
   background-color: $ms-color-whiteTranslucent40;
-  position: absolute;
+  position: fixed;
   bottom: 0;
   left: 0;
   right: 0;

--- a/src/components/Overlay/Overlay.scss
+++ b/src/components/Overlay/Overlay.scss
@@ -28,6 +28,6 @@
   background-color: $ms-color-blackTranslucent40;
 }
 
-.ms-noScroll {
+.ms-u-overflowHidden {
   overflow: hidden;
 }

--- a/src/components/Overlay/Overlay.ts
+++ b/src/components/Overlay/Overlay.ts
@@ -23,12 +23,12 @@ namespace fabric {
 
     public show(): void {
       this.overlayElement.classList.add("is-visible");
-      document.body.classList.add("ms-noScroll");
+      document.body.classList.add("ms-u-overflowHidden");
     }
 
     public hide(): void {
       this.overlayElement.classList.remove("is-visible");
-      document.body.classList.remove("ms-noScroll");
+      document.body.classList.remove("ms-u-overflowHidden");
     }
   }
 }

--- a/src/components/Overlay/Overlay.ts
+++ b/src/components/Overlay/Overlay.ts
@@ -23,10 +23,12 @@ namespace fabric {
 
     public show(): void {
       this.overlayElement.classList.add("is-visible");
+      document.body.classList.add("ms-noScroll");
     }
 
     public hide(): void {
       this.overlayElement.classList.remove("is-visible");
+      document.body.classList.remove("ms-noScroll");
     }
   }
 }

--- a/src/components/Panel/Panel.scss
+++ b/src/components/Panel/Panel.scss
@@ -32,6 +32,15 @@ $ms-panel-close-button-height: 40px;
   display: none;
   height: 100%;
 
+  // Animations -- Default (anchored right)
+  &.animate-in {
+    @include ms-u-slideLeftIn40;
+  }
+
+  &.animate-out {
+    @include ms-u-slideRightOut40;
+  }
+
   &.is-open {
     display: block;
   }
@@ -64,6 +73,22 @@ $ms-panel-close-button-height: 40px;
 //
 .ms-Panel.ms-Panel--xxl {
   max-width: $ms-panel-width-xxl;
+}
+
+//== Modifier: Left anchored panel (anchored left, fixed width)
+// Note: This panel variant should only be used for left nav.
+.ms-Panel--left {
+  @include drop-shadow(-30px, 0, 30px, 30px, .2);
+  left: 0;
+  right: auto;
+
+  &.animate-in {
+    @include ms-u-slideRightIn40;
+  }
+
+  &.animate-out {
+    @include ms-u-slideLeftOut40;
+  }
 }
 
 // The close button in the top right (x)

--- a/src/components/Panel/Panel.scss
+++ b/src/components/Panel/Panel.scss
@@ -32,15 +32,6 @@ $ms-panel-close-button-height: 40px;
   display: none;
   height: 100%;
 
-  // Animations -- Default (anchored right)
-  &.animate-in {
-    @include ms-u-slideLeftIn40;
-  }
-
-  &.animate-out {
-    @include ms-u-slideRightOut40;
-  }
-
   &.is-open {
     display: block;
   }
@@ -73,22 +64,6 @@ $ms-panel-close-button-height: 40px;
 //
 .ms-Panel.ms-Panel--xxl {
   max-width: $ms-panel-width-xxl;
-}
-
-//== Modifier: Left anchored panel (anchored left, fixed width)
-// Note: This panel variant should only be used for left nav.
-.ms-Panel--left {
-  @include drop-shadow(-30px, 0, 30px, 30px, .2);
-  left: 0;
-  right: auto;
-
-  &.animate-in {
-    @include ms-u-slideRightIn40;
-  }
-
-  &.animate-out {
-    @include ms-u-slideLeftOut40;
-  }
 }
 
 // The close button in the top right (x)

--- a/src/components/Panel/Panel.ts
+++ b/src/components/Panel/Panel.ts
@@ -9,22 +9,26 @@ namespace fabric {
    * A host for the panel control
    *
    */
-  const ANIMATE_IN_STATE = "ms-u-slideLeftIn400";
-  const ANIMATE_OUT_STATE = "ms-u-slideRightOut400";
+  const ANIMATE_IN_STATE = "animate-in";
+  const ANIMATE_OUT_STATE = "animate-out";
   const ANIMATION_END = 400;
 
   export class Panel {
 
     private _panel: Element;
     private _panelHost: PanelHost;
+    private _direction: string;
+    private _animateOverlay: boolean;
 
     /**
      *
      * @param {HTMLElement} container - the target container for an instance of Panel
      * @constructor
      */
-    constructor(panel: Element) {
+    constructor(panel: Element,  direction?: string, animateOverlay?: boolean) {
       this._panel = panel;
+      this._direction = direction || "right";
+      this._animateOverlay = animateOverlay || true;
       this._panelHost = new fabric.PanelHost(this._panel, this._animateInPanel);
       this._setEvents();
 

--- a/src/components/Panel/Panel.ts
+++ b/src/components/Panel/Panel.ts
@@ -9,26 +9,22 @@ namespace fabric {
    * A host for the panel control
    *
    */
-  const ANIMATE_IN_STATE = "animate-in";
-  const ANIMATE_OUT_STATE = "animate-out";
+  const ANIMATE_IN_STATE = "ms-u-slideLeftIn400";
+  const ANIMATE_OUT_STATE = "ms-u-slideRightOut400";
   const ANIMATION_END = 400;
 
   export class Panel {
 
     private _panel: Element;
     private _panelHost: PanelHost;
-    private _direction: string;
-    private _animateOverlay: boolean;
 
     /**
      *
      * @param {HTMLElement} container - the target container for an instance of Panel
      * @constructor
      */
-    constructor(panel: Element,  direction?: string, animateOverlay?: boolean) {
+    constructor(panel: Element) {
       this._panel = panel;
-      this._direction = direction || "right";
-      this._animateOverlay = animateOverlay || true;
       this._panelHost = new fabric.PanelHost(this._panel, this._animateInPanel);
       this._setEvents();
 

--- a/src/components/PanelHost/PanelHost.scss
+++ b/src/components/PanelHost/PanelHost.scss
@@ -3,7 +3,7 @@
   @include ms-baseFont;
   bottom: 0;
   left: 0;
-  position: absolute;
+  position: fixed;
   right: 0;
   top: 0;
   z-index: $ms-zIndex-front;

--- a/src/components/PeoplePicker/PeoplePicker.hbs
+++ b/src/components/PeoplePicker/PeoplePicker.hbs
@@ -24,7 +24,7 @@
         {{#each personas}}
           <div class="ms-PeoplePicker-result {{state}}" tabindex="1">
             {{> Persona props=props}}
-              <button class="ms-PeoplePicker-resultAction"><i class="ms-Icon ms-Icon--x"></i></button>
+              <button class="ms-PeoplePicker-resultAction"><i class="ms-Icon ms-Icon--Clear"></i></button>
           </div>
         {{/each}}
       </div>
@@ -32,7 +32,7 @@
     {{#if props.searchMoreText}}
       <button class="ms-PeoplePicker-searchMore">
         <div class="ms-PeoplePicker-searchMoreIcon">
-          <i class="ms-Icon ms-Icon--search"></i>
+          <i class="ms-Icon ms-Icon--Search"></i>
         </div>
         <div class="ms-PeoplePicker-searchMoreText">
           {{props.searchMoreText}}
@@ -49,7 +49,7 @@
         {{#each personas}}
         <li class="ms-PeoplePicker-selectedPerson {{state}}" tabindex="1">
           {{> Persona props=props}}
-            <button class="ms-PeoplePicker-resultAction"><i class="ms-Icon ms-Icon--x"></i></button>
+            <button class="ms-PeoplePicker-resultAction"><i class="ms-Icon ms-Icon--Clear"></i></button>
         </li>
         {{/each}}
       </ul>

--- a/src/components/PeoplePicker/PeoplePicker.scss
+++ b/src/components/PeoplePicker/PeoplePicker.scss
@@ -50,7 +50,7 @@ $ms-Persona-leftPadding: 16px;
     border: 0;
     margin-bottom: 0;
     display: inline-block;
-    width: auto;
+    width: 100%;
 
     .ms-TextField-field {
       min-height: 40px;

--- a/src/components/Pivot/Pivot.hbs
+++ b/src/components/Pivot/Pivot.hbs
@@ -9,7 +9,7 @@
     {{/each}}
     {{#if props.hasEllipsis}}
       <li class="ms-Pivot-link" tabindex="1">
-        <i class="ms-Pivot-ellipsis ms-Icon ms-Icon--ellipsis"></i>
+        <i class="ms-Pivot-ellipsis ms-Icon ms-Icon--More"></i>
       </li>
     {{/if}}
   </ul>

--- a/src/components/Pivot/Pivot.scss
+++ b/src/components/Pivot/Pivot.scss
@@ -30,6 +30,7 @@
   margin-right: 8px;
   padding: 0 8px;
   text-align: center;
+  vertical-align: top;
 
   &:hover {
     cursor: pointer;

--- a/src/components/SearchBox/SearchBox.scss
+++ b/src/components/SearchBox/SearchBox.scss
@@ -98,7 +98,6 @@ $SearchBox-command-color: #F4F4F4;
   display: inline-block;
   font-size: 16px;
   width: 16px;
-  height: 16px;
   margin-left: 12px;
   margin-right: 6px;
   color: $ms-color-themePrimary;
@@ -161,20 +160,6 @@ $SearchBox-command-color: #F4F4F4;
       background-color: transparent;
       padding: 6px 3px 7px $SearchBox-field-padding-left;
     }
-  }
-
-  .ms-SearchBox-icon {
-    position: relative;
-    top: 50%;
-    transform: translateY(-50%);
-    display: inline-block;
-    font-size: 16px;
-    width: 16px;
-    height: 16px;
-    margin-left: 16px;
-    margin-right: 8px;
-    color: $ms-color-themePrimary;
-    vertical-align: top;
   }
 
   .ms-SearchBox-clear,

--- a/src/components/Table/Table.scss
+++ b/src/components/Table/Table.scss
@@ -40,13 +40,8 @@
 
       // But show the mark.
       &::after {
-        @include ms-Icon;
-        content: '\e041';
+        content: '\e73A';
         color: $ms-color-white;
-        font-size: 12px;
-        position: absolute;
-        left: 4px;
-        top: 9px;
       }
     }
   }
@@ -77,18 +72,6 @@
     text-align: left;
     border-bottom: 1px solid $ms-color-neutralLight;
   }
-
-  .ms-Table-rowCheck {
-    &::after {
-      @include ms-Icon;
-      content: '\e041';
-      color: $ms-color-neutralTertiary;
-      font-size: 12px;
-      position: absolute;
-      left: 4px;
-      top: 9px;
-    }
-  }
 }
 
 // On selectable tables, each row has a checkbox.
@@ -99,15 +82,14 @@
   padding: 0;
 
   // Empty checkbox.
-  &::before {
-    border: 1px solid $ms-color-neutralTertiary;
-    content: '';
-    display: block;
-    height: 14px;
-    left: 2px;
+  &::after {
+    @include ms-Icon;
+    content: '\e739';
+    color: $ms-color-neutralTertiary;
+    font-size: 12px;
     position: absolute;
-    top: 6px;
-    width: 14px;
+    left: 4px;
+    top: 1px;
   }
 }
 

--- a/src/components/Table/Table.scss
+++ b/src/components/Table/Table.scss
@@ -40,7 +40,7 @@
 
       // But show the mark.
       &::after {
-        content: '\e73A';
+        @include ms-Icon--CheckboxComposite;
         color: $ms-color-white;
       }
     }
@@ -84,7 +84,7 @@
   // Empty checkbox.
   &::after {
     @include ms-Icon;
-    content: '\e739';
+    @include ms-Icon--Checkbox;
     color: $ms-color-neutralTertiary;
     font-size: 12px;
     position: absolute;

--- a/src/components/TextField/TextField.scss
+++ b/src/components/TextField/TextField.scss
@@ -63,6 +63,7 @@
   width: 100%;
   min-width: 180px;
   outline: 0;
+  text-overflow: ellipsis;
 
   &:hover {
     border-color: $ms-color-neutralSecondaryAlt;

--- a/src/components/TextField/TextField.ts
+++ b/src/components/TextField/TextField.ts
@@ -51,7 +51,7 @@ namespace fabric {
     private _addListeners(): void {
       /** Placeholder - hide/unhide the placeholder  */
       if (this._type.indexOf(TextFieldConsts.Type.Placeholder) >= 0) {
-        this._textField.addEventListener("click", (event: MouseEvent) => {
+        this._textField.addEventListener("focus", (event: MouseEvent) => {
           this._textFieldLabel.style.display = "none";
         });
         this._textField.addEventListener("blur", (event: MouseEvent) => {

--- a/src/documentation/demo.scss
+++ b/src/documentation/demo.scss
@@ -28,7 +28,7 @@ h3 {
 }
 
 .componentDemo {
-  padding-right: 20px;
+  padding: 0 20px;
 }
 
 #componentWrapper {
@@ -268,7 +268,6 @@ html[dir=rtl] {
     position: absolute;
     top: $header-height;
     bottom: 0;
-    padding: 0 0 0 20px;
     overflow-x: auto;
     overflow-y: hidden;
     -webkit-transform: translateZ(0);

--- a/src/documentation/pages/Button/Button.md
+++ b/src/documentation/pages/Button/Button.md
@@ -56,6 +56,7 @@ State | Applied to | Result
     <head>
         <link rel="stylesheet" href="fabric.min.css">
         <link rel="stylesheet" href="fabric.components.min.css">
+        <script src="fabric.min.js"></script>
     </head>
     ```
 2. Copy the HTML from one of the samples above into your page. For example:
@@ -66,7 +67,15 @@ State | Applied to | Result
     </code>
 </pre>
 --->
-3. Replace the sample HTML content (such as the content of `.ms-Button-label`) with your content.
+3. Add the following `<script>` tag to your page, below the references to Fabric's JS, to instantiate all Button components on the page:
+<!---
+<pre>
+    <code>
+{{renderPartialPre "Button" "ButtonExampleJS" "" false}}
+    </code>
+</pre>
+--->
+4. Replace the sample HTML content (such as the content of `.ms-Button-label`) with your content.
 
 ## Dependencies
 This component has no dependencies.

--- a/src/documentation/pages/Button/examples/ButtonExampleJS.hbs
+++ b/src/documentation/pages/Button/examples/ButtonExampleJS.hbs
@@ -1,6 +1,8 @@
 <script type="text/javascript">
     var ButtonElements = document.querySelectorAll(".ms-Button");
     for(var i = 0; i < ButtonElements.length; i++) {
-        new fabric['Button'](ButtonElements[i]);
+        new fabric['Button'](ButtonElements[i], function() {
+        	// Insert Event Here
+        });
     }
 </script>

--- a/src/documentation/pages/Callout/examples/CalloutExampleModel.js
+++ b/src/documentation/pages/Callout/examples/CalloutExampleModel.js
@@ -30,7 +30,7 @@ var CalloutExampleModel = {
         "component": "CommandButton",
         "props": {
           "label": "Command",
-          "icon": "check",
+          "icon": "CheckMark",
           "tag": "button",
           "modifier": "inline",
           "iconColor": "green"
@@ -40,7 +40,7 @@ var CalloutExampleModel = {
         "component": "CommandButton",
         "props": {
           "label": "Command",
-          "icon": "x",
+          "icon": "Clear",
           "tag": "button",
           "modifier": "inline",
           "iconColor": "red"
@@ -61,7 +61,7 @@ var CalloutExampleModel = {
     "title": "All of your favorite people",
     "subText": "Message body is optional. If help documentation is available, consider adding a link to learn more at the bottom.",
     "modifier": "close",
-    "closeIcon": "x",
+    "closeIcon": "Clear",
     "arrowPosition": "arrowLeft",
     "actions": [
       {

--- a/src/documentation/pages/List/List.md
+++ b/src/documentation/pages/List/List.md
@@ -14,11 +14,12 @@ A standard vertical list of items.
 This component has only the default state.
 
 ## Using this component
-1. Confirm that you have references to Fabric's CSS on your page:
+1. Confirm that you have references to Fabric's CSS and JavaScript on your page:
     ```
     <head>
         <link rel="stylesheet" href="fabric.min.css">
         <link rel="stylesheet" href="fabric.components.min.css">
+        <script src="fabric.min.js"></script>
     </head>
     ```
 2. Copy the HTML from the sample above into your page. For example: 
@@ -29,7 +30,15 @@ This component has only the default state.
     </code>
 </pre>
 --->
-3. Replace the content with whatever you'd like to display as a list. The samples use `.ms-ListItem` components, but you can place any content within `.ms-List`.
+3. Add the following `<script>` tag to your page, below the references to Fabric's JS, to instantiate all ListItem components on the page:
+<!---
+<pre>
+    <code>
+{{renderPartialPre "List" "ListJS" "" false}}
+    </code>
+</pre>
+--->
+4. Replace the content with whatever you'd like to display as a list. The samples use `.ms-ListItem` components, but you can place any content within `.ms-List`.
 
 ## Dependencies
 This component has no dependencies on other components, although it does often contain ListItem components.

--- a/src/documentation/pages/MessageBar/examples/MessageBarExampleProps.js
+++ b/src/documentation/pages/MessageBar/examples/MessageBarExampleProps.js
@@ -12,7 +12,7 @@ var MessageBarExampleProps = {
   },
   "blocked": {
     "modifier": "ms-MessageBar--blocked",
-    "iconModifiers": "ms-Icon--Blocked2"
+    "iconModifiers": "ms-Icon--Blocked"
   },
   "warning": {
     "modifier": "ms-MessageBar--warning",

--- a/src/documentation/pages/Panel/Panel.md
+++ b/src/documentation/pages/Panel/Panel.md
@@ -61,8 +61,16 @@ State | Applied to | Result
     </code>
 </pre>
 --->
-3. Verify that the component is working the same as in the sample above.
-4. Replace the sample HTML content (such as the content of `.ms-Panel-content`) with your content.
+3. Add the following `<script>` tag to your page, below the references to Fabric's JS, to instantiate all Panel components on the page:
+<!---
+<pre>
+    <code>
+{{renderPartialPre "Panel" "PanelDocExampleJS" "" false}}
+    </code>
+</pre>
+--->
+4. Verify that the component is working the same as in the sample above.
+5. Replace the sample HTML content (such as the content of `.ms-Panel-content`) with your content.
 
 <!---
 {{> PanelDocExampleJS}}

--- a/src/documentation/pages/Panel/examples/PanelExample.hbs
+++ b/src/documentation/pages/Panel/examples/PanelExample.hbs
@@ -1,1 +1,4 @@
-{{> Panel props=props}}
+<div class="ms-PanelDefaultExample ms-PanelExample">
+    {{> Button props=props.button}}
+    {{> Panel props=props}}
+</div>

--- a/src/documentation/pages/PersonaCard/PersonaCard.md
+++ b/src/documentation/pages/PersonaCard/PersonaCard.md
@@ -39,3 +39,6 @@ The visualization of details of an individual including Skype contact details, e
 ## Dependencies
 This component uses a Persona component to present the person, an OrgChart to present the persona's position within the organization, and a Link for navigation.
 
+<!---
+{{> PersonaCardExampleJS }}
+--->

--- a/src/documentation/templates/samples-index.html
+++ b/src/documentation/templates/samples-index.html
@@ -7,57 +7,6 @@
     <link rel="stylesheet" href="../demo.css">
 	<link rel="stylesheet" href="../css/fabric.min.css">
 	<link rel="stylesheet" href="../css/fabric.components.min.css">
-    <script type="text/javascript">
-
-        // Documentation javascript
-        document.addEventListener("DOMContentLoaded", function(){
-            // Add Click handlers on DOM ready
-            addClickHandlers();
-            var docContent = document.getElementById('ContentContainer');
-            var docContentFrame = docContent.getElementsByTagName('iframe')[0];
-            var componentLinks = document.querySelectorAll(".LinkContainer a");
-            componentLinks[0].click();
-
-            function addClickHandlers(){
-                componentLinksHandler();
-                sectionCollapseHandler();
-            }
-
-            // Add click handlers for sidebar links
-            function componentLinksHandler() {
-                var componentLinks = document.querySelectorAll(".LinkContainer a");
-                componentLinks.forEach(function(ele){
-                    ele.addEventListener("click", function(e) {
-                        e.preventDefault();
-                        var url = ele.getAttribute("href");
-                        docContentFrame.setAttribute("src", url);
-                        removeSelected();
-                        ele.classList.add("is-selected");
-                    });
-                });
-            }
-
-            // Add click handler for collapsing and expanding sidebar sections
-            function sectionCollapseHandler() {
-                var sectionHeaders = document.querySelectorAll(".SidebarSection > button");
-                sectionHeaders.forEach(function(ele) {
-                    ele.addEventListener("click", function(e) {
-                        var container = ele.parentElement;
-                        var icon = ele.getElementsByTagName("i")[0];
-                        container.classList.toggle("is-expanded");
-                    });
-                });
-            }
-
-            // Remove currently selected link
-            function removeSelected() {
-                var selectedLinks = document.querySelectorAll(".LinkContainer a.is-selected");
-                selectedLinks.forEach(function(ele) {
-                    ele.classList.remove("is-selected");
-                });
-            }
-        });
-    </script>
 </head>
 <body>
     <div id="MainContainer">
@@ -92,5 +41,54 @@
             <iframe src="" width="100%" height="100%" frameborder="0"></iframe>
         </div>
     </div>
+    <script type="text/javascript">
+         // Add Click handlers on DOM ready
+        addClickHandlers();
+        var docContent = document.getElementById('ContentContainer');
+        var docContentFrame = docContent.getElementsByTagName('iframe')[0];
+        var componentLinks = document.querySelectorAll(".LinkContainer a");
+        componentLinks[0].click();
+
+        function addClickHandlers(){
+            componentLinksHandler();
+            sectionCollapseHandler();
+        }
+
+        // Add click handlers for sidebar links
+        function componentLinksHandler() {
+            var componentLinks = document.querySelectorAll(".LinkContainer a");
+            for (var i = 0; i < componentLinks.length; i++) {
+                var item = componentLinks[i];
+                item.addEventListener("click", function(e) {
+                    e.preventDefault();
+                    var url = this.getAttribute("href");
+                    docContentFrame.setAttribute("src", url);
+                    removeSelected();
+                    this.classList.add("is-selected");
+                });
+            }
+        }
+
+        // Add click handler for collapsing and expanding sidebar sections
+        function sectionCollapseHandler() {
+            var sectionHeaders = document.querySelectorAll(".SidebarSection > button");
+            for (var i = 0; i < sectionHeaders.length; i++) {
+                var item = sectionHeaders[i];
+                item.addEventListener("click", function(e) {
+                    var container = this.parentElement;
+                    container.classList.toggle("is-expanded");
+                });
+            }
+        }
+
+        // Remove currently selected link
+        function removeSelected() {
+            var selectedLinks = document.querySelectorAll(".LinkContainer a.is-selected");
+            for (var i = 0; i < selectedLinks.length; i++) {
+                var item = selectedLinks[i];
+                item.classList.remove("is-selected");
+            }
+        }
+    </script>
 </body>
 </html>


### PR DESCRIPTION
This PR contains bug fixes for some components as well as documentation updates.  Below are a list of changes, as well as screenshots with before and after, if applicable. 

### List of changes

- Changed forEach to for loop, in localhost documentation.  Fixes bug in Firefox.
- Fixed PersonaCard missing the script file, so the example component wasn't functioning correctly
- Fixed TextField component not removing the label/placeholder when a user tabs to it, rather than clicks.  I changed the eventlistener from "click" to "focus"
- Fixed SearchBox-icon incorrect height in input, as well as duplicate rules.   Removing the height: 16px seems to fix this issue.

**BEFORE**
![icon-before](https://cloud.githubusercontent.com/assets/1291968/17496988/91896660-5d74-11e6-9643-3d0b549019ae.png)

**AFTER**
![icon-after](https://cloud.githubusercontent.com/assets/1291968/17496990/92f14360-5d74-11e6-934e-38dc21df9e80.png)

- Fixed the textfield component placeholder being cut off in the PeoplePicker documentation.  I changed the parent container to have a width of 100% instead of auto, as well as adding a text-overflow: ellipsis as a fallback.

**BEFORE**
![textfield-before](https://cloud.githubusercontent.com/assets/1291968/17496907/27109f88-5d74-11e6-99ee-8e254c662288.png)

**AFTER**
![textfield-after](https://cloud.githubusercontent.com/assets/1291968/17496910/2dded5dc-5d74-11e6-8078-b72f933e3ffd.png)


- I added in JS in the component documentation for Panel
- I changed the padding for documentation from the content container, to the componentDemo class instead, so the Overlay component will display correctly

**BEFORE**
![padding-before](https://cloud.githubusercontent.com/assets/1291968/17496857/fc473ece-5d73-11e6-9e11-a73de6d1e1e9.png)

**AFTER**
![padding-after](https://cloud.githubusercontent.com/assets/1291968/17496862/fd883ebe-5d73-11e6-8a34-ca5c1a5ac22a.png)


-  I fixed incorrect line-height on the Dropdown component.  Selected and disabled options had a line height of 40px.  This addresses issue #78 

**BEFORE**
![dropdown-bug](https://cloud.githubusercontent.com/assets/1291968/17496824/d01e1034-5d73-11e6-82a0-2cc8b9431859.png)

**AFTER**
![dropdown-after](https://cloud.githubusercontent.com/assets/1291968/17497562/56fe287a-5d77-11e6-94c6-17765510319c.png)

- Fixed ContextualMenu's text overflow bug ([Issue #65 ](https://github.com/OfficeDev/office-ui-fabric-js/issues/65)) I added a max-width of 220px (matching the class --hasIcons's max width), and added text-overflow ellipsis to the menu items. 

**BEFORE**
![contextualmenu-before](https://cloud.githubusercontent.com/assets/1291968/17528109/cbd4a0c4-5e22-11e6-942e-26e45884977d.png)

**AFTER**
![contextualmenu-after](https://cloud.githubusercontent.com/assets/1291968/17528111/cd0560d2-5e22-11e6-9cee-efbfe365016c.png)


- Fixes issues in #27.  Panel and overlay originally had position absolute on them, which resulted in incorrect position when the user isn't in the very top of the page.  Position Fixed solves this issue.

- Updated several components missing MDL2 icons  (DatePicker, FacePile, ListItem, MessageBanner, PeoplePicker, Table, Callout, Pivot)

- Added example JS to button component documentation
- Fix pivot menuitem being misaligned.

**BEFORE**
![pivot-before](https://cloud.githubusercontent.com/assets/1291968/17570468/5e40d214-5f01-11e6-8929-0aa91865a7f4.png)


**AFTER**
![pivot-after](https://cloud.githubusercontent.com/assets/1291968/17570472/623470ba-5f01-11e6-92f6-405d6980904e.png)
