### PR TITLE
Remove high contrast media queries from link

### DIFF
--- a/src/components/Link/Link.scss
+++ b/src/components/Link/Link.scss
@@ -23,14 +23,6 @@
   &:active {
     color: $ms-color-themePrimary;
   }
-
-  @media screen and (-ms-high-contrast: active) {
-    color: $ms-color-contrastBlackLink;
-  }
-
-  @media screen and (-ms-high-contrast: black-on-white) {
-    color: $ms-color-contrastWhiteLink;
-  }
 }
 
 .ms-Link {


### PR DESCRIPTION
Remove high contrast media queries from link since edge/ie will automatically style the link colors.