### PR TITLE
Leddie24/component cleanup

### DIFF
--- a/gulp/modules/Config.js
+++ b/gulp/modules/Config.js
@@ -174,7 +174,10 @@ var Config = function() {
           var template = hbs.compile(fileContents);
           var thisProps = {props: props};
           var templateString = new hbs.SafeString(template(thisProps));
-          return ' ' + templateString;
+          var commentRegex = /(<!--.+-->)+/g;
+          templateString = ' ' + templateString;
+          templateString = templateString.replace(commentRegex, '');
+          return templateString;
         }.bind(this)
       }
   };

--- a/src/documentation/pages/CommandBar/CommandBar.md
+++ b/src/documentation/pages/CommandBar/CommandBar.md
@@ -1,5 +1,5 @@
 # Command Bar
-Commanding surface for panels, pages, and applications. Unlike the NavBar, this component should not navigate to other pages.
+Commanding surface for panels, pages, and applications. When planning to use the surface for navigation only, consider the NavBar variant.
 
 ## Variants
 

--- a/src/documentation/templates/componentDemo.html
+++ b/src/documentation/templates/componentDemo.html
@@ -20,4 +20,18 @@
 <body class="componentDemo">
 <%= contents %>
 </body>
+<script>
+  function stripComments() {
+      var codeBlocks = document.getElementsByTagName("code");
+      var commentRegex = /(<!--.+-->)+/g;
+      var matches = [];
+
+      for (var i = 0; i < codeBlocks.length; i++) {
+        var code = codeBlocks[i].innerText;
+        codeBlocks[i].innerText = code.replace(commentRegex, '');
+      }
+    }
+
+    stripComments();
+</script>
 </html>

--- a/src/documentation/templates/componentDemo.html
+++ b/src/documentation/templates/componentDemo.html
@@ -20,18 +20,4 @@
 <body class="componentDemo">
 <%= contents %>
 </body>
-<script>
-  function stripComments() {
-      var codeBlocks = document.getElementsByTagName("code");
-      var commentRegex = /(<!--.+-->)+/g;
-      var matches = [];
-
-      for (var i = 0; i < codeBlocks.length; i++) {
-        var code = codeBlocks[i].innerText;
-        codeBlocks[i].innerText = code.replace(commentRegex, '');
-      }
-    }
-
-    stripComments();
-</script>
 </html>

--- a/src/documentation/templates/samples-index.html
+++ b/src/documentation/templates/samples-index.html
@@ -11,7 +11,7 @@
 <body>
     <div id="MainContainer">
         <div id="Header" class="ms-bgColor-themeDark">
-            <div class="Header-Title ms-font-xxl ms-fontColor-white">Office UI Components</div>
+            <div class="Header-Title ms-font-xxl ms-fontColor-white">Office UI Fabric JS</div>
             <div class="Header-buttons">
                 <a href="https://github.com/OfficeDev/office-ui-fabric-js/" class="Header-button ms-fontColor-white">Github</a>
             </div>


### PR DESCRIPTION
List of changes

- Changed commandbar text (Bug 239147: CommandBar text doesn't make sense - we should remove the sentence about the NavBar.)
- Stripped out html comments in example code (Bug 239148:Copyright text is being pulled in for each template in handlebars).
- Changed title of localhost docs (Bug 239150:Change name of project in locally built docs site to Office UI Fabric JS)