### PR TITLE
Fix ContextualHost, PeoplePicker, CommandButton, MessageBanner

### DIFF
--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -20,6 +20,10 @@
   min-width: 80px;
   padding: 4px 20px 6px;
 
+  &.is-hidden {
+    display: none;
+  }
+
   &:hover {
     background-color: $ms-color-neutralLight;
     border-color: $ms-color-neutralLight;

--- a/src/components/ContextualHost/ContextualHost.ts
+++ b/src/components/ContextualHost/ContextualHost.ts
@@ -29,7 +29,6 @@ namespace fabric {
   const ARROW_BOTTOM_CLASS = "ms-ContextualHost--arrowBottom";
   const ARROW_RIGHT_CLASS = "ms-ContextualHost--arrowRight";
   const MODIFIER_BASE = "ms-ContextualHost--";
-  const HAS_SUBMENU = "ms-ContextualMenu-item--hasMenu";
   const ARROW_SIZE = 28;
   const ARROW_OFFSET = 8;
 
@@ -53,7 +52,6 @@ namespace fabric {
     private _children: Array<ContextualHost>;
     private _hasArrow: boolean;
     private _arrow: Element;
-    private _hasSubMenu: boolean;
 
     constructor(
         content: HTMLElement,
@@ -62,8 +60,7 @@ namespace fabric {
         hasArrow: boolean = true,
         modifiers?: Array<string>,
         matchTargetWidth?: boolean,
-        disposalCallback?: Function,
-        hasSubMenu: boolean = false
+        disposalCallback?: Function
       ) {
       this._resizeAction = this._resizeAction.bind(this);
       this._dismissAction = this._dismissAction.bind(this);
@@ -75,7 +72,6 @@ namespace fabric {
       this._contextualHostMain.appendChild(content);
       this._hasArrow = hasArrow;
       this._arrow = this._container.querySelector(CONTEXT_HOST_BEAK_CLASS);
-      this._hasSubMenu = hasSubMenu;
 
       this._targetElement = targetElement;
       this._openModal();
@@ -381,10 +377,6 @@ namespace fabric {
             this.disposeModal();
           }
         } else {
-          this.disposeModal();
-        }
-      } else {
-        if (!e.target.parentElement.classList.contains(HAS_SUBMENU) && this._hasSubMenu) {
           this.disposeModal();
         }
       }

--- a/src/components/ContextualHost/ContextualHost.ts
+++ b/src/components/ContextualHost/ContextualHost.ts
@@ -53,6 +53,7 @@ namespace fabric {
     private _children: Array<ContextualHost>;
     private _hasArrow: boolean;
     private _arrow: Element;
+    private _hasSubMenu: boolean;
 
     constructor(
         content: HTMLElement,
@@ -61,7 +62,8 @@ namespace fabric {
         hasArrow: boolean = true,
         modifiers?: Array<string>,
         matchTargetWidth?: boolean,
-        disposalCallback?: Function
+        disposalCallback?: Function,
+        hasSubMenu: boolean = false
       ) {
       this._resizeAction = this._resizeAction.bind(this);
       this._dismissAction = this._dismissAction.bind(this);
@@ -73,6 +75,7 @@ namespace fabric {
       this._contextualHostMain.appendChild(content);
       this._hasArrow = hasArrow;
       this._arrow = this._container.querySelector(CONTEXT_HOST_BEAK_CLASS);
+      this._hasSubMenu = hasSubMenu;
 
       this._targetElement = targetElement;
       this._openModal();
@@ -381,7 +384,7 @@ namespace fabric {
           this.disposeModal();
         }
       } else {
-        if (!e.target.parentElement.classList.contains(HAS_SUBMENU)) {
+        if (!e.target.parentElement.classList.contains(HAS_SUBMENU) && this._hasSubMenu) {
           this.disposeModal();
         }
       }

--- a/src/components/ContextualMenu/ContextualMenu.ts
+++ b/src/components/ContextualMenu/ContextualMenu.ts
@@ -17,7 +17,11 @@ namespace fabric {
     private _position: string;
     private _host: ContextualHost;
 
-    constructor(container: Element, hostTarget: Element, position?: string) {
+    constructor(
+        container: Element,
+        hostTarget: Element,
+        position?: string
+      ) {
       this._container = container;
       this._hostTarget = hostTarget;
       this._position = position ? position : MODAL_POSITION;
@@ -41,6 +45,9 @@ namespace fabric {
           this._multiSelect(target);
         } else {
           this._singleSelect(target);
+          if (!target.parentElement.classList.contains("ms-ContextualMenu-item--hasMenu")) {
+            this._host.disposeModal();
+          }
         }
       }
     }
@@ -94,7 +101,10 @@ namespace fabric {
 
     private _createModalHostView(container: Element, position: string, hostTarget: Element) {
       container.classList.remove("is-hidden");
-      this._host = new fabric.ContextualHost(<HTMLElement>container, position, hostTarget, false);
+      this._host = new fabric.ContextualHost(<HTMLElement>container,
+                                          position,
+                                          hostTarget,
+                                          false);
       let event: Event = document.createEvent("Event");
       event.initEvent("hostAdded", true, true);
       container.dispatchEvent(event);

--- a/src/components/PeoplePicker/PeoplePicker.scss
+++ b/src/components/PeoplePicker/PeoplePicker.scss
@@ -21,6 +21,9 @@ $ms-Persona-leftPadding: 16px;
 .ms-PeoplePicker-searchBox {
   border-bottom: 1px solid $ms-color-neutralTertiaryAlt;
   cursor: text;
+  flex-flow: row wrap;
+  display: flex;
+  align-items: stretch;
 
   &:hover {
     border-color: $ms-color-neutralSecondaryAlt;
@@ -51,6 +54,7 @@ $ms-Persona-leftPadding: 16px;
     margin-bottom: 0;
     display: inline-block;
     width: 100%;
+    flex: 1;
 
     .ms-TextField-field {
       min-height: 40px;

--- a/src/components/PeoplePicker/PeoplePicker.ts
+++ b/src/components/PeoplePicker/PeoplePicker.ts
@@ -52,8 +52,7 @@ namespace fabric {
         false,
         [""],
         true,
-        this._contextHostCallBack.bind(this),
-        false
+        this._contextHostCallBack.bind(this)
       );
       this._peoplePickerSearchBox.classList.add("is-active");
       this._isContextualMenuOpen = true;

--- a/src/components/PeoplePicker/PeoplePicker.ts
+++ b/src/components/PeoplePicker/PeoplePicker.ts
@@ -52,7 +52,8 @@ namespace fabric {
         false,
         [""],
         true,
-        this._contextHostCallBack.bind(this)
+        this._contextHostCallBack.bind(this),
+        false
       );
       this._peoplePickerSearchBox.classList.add("is-active");
       this._isContextualMenuOpen = true;
@@ -117,7 +118,7 @@ namespace fabric {
         actionBtn.addEventListener("click", this._removeResult.bind(this), true);
       }
 
-      actionIcon.classList.add("ms-Icon", "ms-Icon--x");
+      actionIcon.classList.add("ms-Icon", "ms-Icon--Cancel");
 
       actionBtn.appendChild(actionIcon);
 

--- a/src/components/PeoplePicker/PeoplePicker.ts
+++ b/src/components/PeoplePicker/PeoplePicker.ts
@@ -81,7 +81,6 @@ namespace fabric {
 
       let currentResult = this._findElement(e.target, "ms-Persona");
       let clonedResult: Element = <Element>currentResult.cloneNode(true);
-      let openHost = document.querySelector(".ms-ContextualHost.is-open");
 
       // if facePile - add to members list / else tokenize
       if (this._container.classList.contains("ms-PeoplePicker--facePile")) {
@@ -91,7 +90,7 @@ namespace fabric {
       }
 
       // Close the open contextual host
-      openHost.classList.remove("is-open");
+      this._contextualHostView.disposeModal();
     }
 
     private _findElement(childObj: Element, className: string ) {

--- a/src/components/Persona/Persona.scss
+++ b/src/components/Persona/Persona.scss
@@ -682,7 +682,7 @@ $ms-Persona-presenceSizeXl: 28px;
 //== Modifier: FacePile
 //
 .ms-Persona.ms-Persona--token {
-  display: inline-block;
+  display: inline-flex;
   width: auto;
   background-color: $ms-color-neutralLighter;
   border-radius: 20px;

--- a/src/documentation/pages/CommandButton/examples/CommandButtonExampleModel.js
+++ b/src/documentation/pages/CommandButton/examples/CommandButtonExampleModel.js
@@ -1,13 +1,13 @@
 var CommandButtonExampleModel = {
   "props": { 
     "label": "Command",
-    "icon": "CircleFill",
+    "icon": "CircleRing",
     "tag": "button",
     "iconColor": "themePrimary"
   },
   "propsDropdown": {
     "label": "New",
-    "icon": "CircleFill",
+    "icon": "CircleRing",
     "tag": "button",
     "dropdownIcon": "ChevronDown",
     "iconColor": "themePrimary",
@@ -49,7 +49,7 @@ var CommandButtonExampleModel = {
   },
   "propsSplit": {
     "label": "Reply",
-    "icon": "CircleFill",
+    "icon": "CircleRing",
     "splitIcon": "ChevronDown",
     "iconColor": "themePrimary",
     "tag": "button",
@@ -83,13 +83,13 @@ var CommandButtonExampleModel = {
     }
   },
   "propsNoLabel": {
-    "icon": "CircleFill",
+    "icon": "CircleRing",
     "modifier": "noLabel",
     "tag": "button",
     "iconColor": "themePrimary"
   },
   "propsNoLabelSplit": {
-    "icon": "CircleFill",
+    "icon": "CircleRing",
     "modifier": "noLabel",
     "tag": "button",
     "splitIcon": "ChevronDown",
@@ -125,20 +125,20 @@ var CommandButtonExampleModel = {
   },
   "propsInline": {
     "label": "Command",
-    "icon": "CircleFill",
+    "icon": "CircleRing",
     "tag": "button",
     "modifier": "inline",
     "iconColor": "green"
   },
   "propsDisabled": {
     "label": "Command",
-    "icon": "CircleFill",
+    "icon": "CircleRing",
     "tag": "button",
     "iconColor": "themePrimary",
     "disabled": true
   },
   "propsActionButton": {
-    "icon": "CircleFill",
+    "icon": "CircleRing",
     "modifier": "actionButton",
     "tag": "button",
     "iconColor": "themePrimary"
@@ -150,7 +150,7 @@ var CommandButtonExampleModel = {
   },
   "propsPivot": {
     "label": "New",
-    "icon": "CircleFill",
+    "icon": "CircleRing",
     "tag": "button",
     "dropdownIcon": "ChevronDown",
     "iconColor": "themePrimary",

--- a/src/documentation/pages/MessageBanner/examples/MessageBannerExample.hbs
+++ b/src/documentation/pages/MessageBanner/examples/MessageBannerExample.hbs
@@ -1,4 +1,4 @@
 <div class="docs-MessageBannerExample">
   {{> MessageBanner props=props }}
-  <button class="ms-Button docs-MessageBannerExample-button">Show the banner</button>
+  <button class="ms-Button docs-MessageBannerExample-button is-hidden">Show the banner</button>
 </div>

--- a/src/documentation/pages/MessageBanner/examples/MessageBannerExampleJS.hbs
+++ b/src/documentation/pages/MessageBanner/examples/MessageBannerExampleJS.hbs
@@ -2,9 +2,20 @@
   var MessageBannerExample = document.querySelector('.docs-MessageBannerExample');
   var MessageBanner = new fabric['MessageBanner'](MessageBannerExample.querySelector('.ms-MessageBanner'));
   var MessageBannerButton = MessageBannerExample.querySelector('.docs-MessageBannerExample-button');
-  
+  var MessageBannerCloseButton = MessageBannerExample.querySelector('.ms-MessageBanner-close');
+
   // When clicking the button, open the MessageBanner
   MessageBannerButton.onclick = function() {
     MessageBanner.showBanner();
+    this.style.display = 'none';
   };
+
+  MessageBannerButton.style.display = 'none';
+
+  // Hide "Show the Banner Button" when banner is active
+  MessageBannerCloseButton.addEventListener("click", function(){
+  	setTimeout(function() {
+  		MessageBannerButton.style.display = '';
+  	}, 500);
+  });
 </script>

--- a/src/documentation/pages/MessageBanner/examples/MessageBannerExampleJS.hbs
+++ b/src/documentation/pages/MessageBanner/examples/MessageBannerExampleJS.hbs
@@ -7,15 +7,13 @@
   // When clicking the button, open the MessageBanner
   MessageBannerButton.onclick = function() {
     MessageBanner.showBanner();
-    this.style.display = 'none';
+    this.classList.add("is-hidden");
   };
-
-  MessageBannerButton.style.display = 'none';
 
   // Hide "Show the Banner Button" when banner is active
   MessageBannerCloseButton.addEventListener("click", function(){
   	setTimeout(function() {
-  		MessageBannerButton.style.display = '';
+  		MessageBannerButton.classList.remove("is-hidden");
   	}, 500);
   });
 </script>


### PR DESCRIPTION
List of changes

- Add MDL2 icon (Cancel) to PeoplePicker
- PeoplePicker works now!  ContextualHost is working properly, so you can actually select people inside the component now
- Updated ContextualMenu, fixed the click handler inside the component so it works properly with multi/single select
- Changed icons in CommandButton to use CircleRing to show similarity with CommandBar
- Changed MessageBanner.  I hid the "Show the Banner" button on load.  Once the user closes the banner, the button appears. 

Bugs addressed:
- Bug 239152:Message Banner seems broken - already opened off the instantiating button
- Bug 239157:Can't select people in People Picker
- Bug 239159:Make CommandButtons unfilled circles (like CommandBar)
