### PR TITLE
Update 'ghdocs' with latest built output

### DIFF
--- a/ghdocs/components/Breadcrumb.md
+++ b/ghdocs/components/Breadcrumb.md
@@ -34,7 +34,7 @@ State | Applied to | Result
 
 <pre>
     <code>
- &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+ 
 &lt;div class&#x3D;&quot;ms-Breadcrumb &quot;&gt;
   &lt;div class&#x3D;&quot;ms-Breadcrumb-overflow&quot;&gt;
     &lt;div class&#x3D;&quot;ms-Breadcrumb-overflowButton ms-Icon ms-Icon--More&quot; tabindex&#x3D;&quot;1&quot;&gt;&lt;/div&gt;

--- a/ghdocs/components/Button.md
+++ b/ghdocs/components/Button.md
@@ -68,7 +68,7 @@ State | Applied to | Result
 
 <pre>
     <code>
- &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+ 
 &lt;button class&#x3D;&quot;ms-Button 
   
   &quot;&gt;

--- a/ghdocs/components/Callout.md
+++ b/ghdocs/components/Callout.md
@@ -75,7 +75,7 @@ This component has only the default state.
 <pre>
     <code>
  &lt;div class&#x3D;&quot;ms-CalloutExample&quot;&gt;  
-  &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+  
   
   &lt;div class&#x3D;&quot;ms-Callout 
        
@@ -89,7 +89,7 @@ This component has only the default state.
           &lt;p class&#x3D;&quot;ms-Callout-subText  ms-Callout-subText-- &quot;&gt;Message body is optional. If help documentation is available, consider adding a link to learn more at the bottom.&lt;/p&gt;
         &lt;/div&gt;
         &lt;div class&#x3D;&quot;ms-Callout-actions&quot;&gt;
-              &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+              
   
   &lt;a class&#x3D;&quot;ms-Link  &quot; 
      
@@ -102,7 +102,7 @@ This component has only the default state.
     &lt;/div&gt;
   &lt;/div&gt;
   &lt;div class&#x3D;&quot;ms-CalloutExample-button&quot;&gt;
-    &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+    
     &lt;button class&#x3D;&quot;ms-Button 
       
       &quot;&gt;

--- a/ghdocs/components/CheckBox.md
+++ b/ghdocs/components/CheckBox.md
@@ -31,7 +31,7 @@ State | Applied to | Result
 
 <pre>
     <code>
- &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+ 
 
 &lt;div class&#x3D;&quot;ms-CheckBox&quot;&gt; 
     &lt;input tabindex&#x3D;&quot;-1&quot; type&#x3D;&quot;checkbox&quot; class&#x3D;&quot;ms-CheckBox-input&quot;&gt;

--- a/ghdocs/components/ChoiceFieldGroup.md
+++ b/ghdocs/components/ChoiceFieldGroup.md
@@ -25,13 +25,13 @@ Used to indicate a single choice from multiple options.
 
 <pre>
     <code>
- &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+ 
 &lt;div class&#x3D;&quot;ms-ChoiceFieldGroup&quot; id&#x3D;&quot;choicefieldgroup&quot; role&#x3D;&quot;radiogroup&quot;&gt;
   &lt;div class&#x3D;&quot;ms-ChoiceFieldGroup-title&quot;&gt;
     &lt;label class&#x3D;&quot;ms-Label  is-required &quot;&gt;Unselected&lt;/label&gt;
   &lt;/div&gt;
   &lt;ul class&#x3D;&quot;ms-ChoiceFieldGroup-list&quot;&gt;
-    &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+    
 
 &lt;div class&#x3D;&quot;ms-RadioButton&quot;&gt; 
     &lt;input tabindex&#x3D;&quot;-1&quot; type&#x3D;&quot;radio&quot; class&#x3D;&quot;ms-RadioButton-input&quot;&gt;
@@ -44,7 +44,7 @@ Used to indicate a single choice from multiple options.
         &lt;span class&#x3D;&quot;ms-Label&quot;&gt;Option 1&lt;/span&gt;
     &lt;/label&gt;
 &lt;/div&gt; 
-    &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+    
 
 &lt;div class&#x3D;&quot;ms-RadioButton&quot;&gt; 
     &lt;input tabindex&#x3D;&quot;-1&quot; type&#x3D;&quot;radio&quot; class&#x3D;&quot;ms-RadioButton-input&quot;&gt;
@@ -57,7 +57,7 @@ Used to indicate a single choice from multiple options.
         &lt;span class&#x3D;&quot;ms-Label&quot;&gt;Option 2&lt;/span&gt;
     &lt;/label&gt;
 &lt;/div&gt; 
-    &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+    
 
 &lt;div class&#x3D;&quot;ms-RadioButton&quot;&gt; 
     &lt;input tabindex&#x3D;&quot;-1&quot; type&#x3D;&quot;radio&quot; class&#x3D;&quot;ms-RadioButton-input&quot;&gt;
@@ -71,7 +71,7 @@ Used to indicate a single choice from multiple options.
         &lt;span class&#x3D;&quot;ms-Label&quot;&gt;Option 3&lt;/span&gt;
     &lt;/label&gt;
 &lt;/div&gt; 
-    &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+    
 
 &lt;div class&#x3D;&quot;ms-RadioButton&quot;&gt; 
     &lt;input tabindex&#x3D;&quot;-1&quot; type&#x3D;&quot;radio&quot; class&#x3D;&quot;ms-RadioButton-input&quot;&gt;

--- a/ghdocs/components/CommandBar.md
+++ b/ghdocs/components/CommandBar.md
@@ -1,5 +1,5 @@
 # Command Bar
-Commanding surface for panels, pages, and applications. Unlike the NavBar, this component should not navigate to other pages.
+Commanding surface for panels, pages, and applications. When planning to use the surface for navigation only, consider the NavBar variant.
 
 ## Variants
 
@@ -41,17 +41,17 @@ State | Applied to | Result
 
 <pre>
     <code>
- &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+ 
 &lt;div class&#x3D;&quot;ms-CommandBar &quot;&gt;
     &lt;div class&#x3D;&quot;ms-CommandBar-sideCommands&quot;&gt;
-        &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+        
 &lt;div class&#x3D;&quot;ms-CommandButton  ms-CommandButton--noLabel  &quot;&gt;
   &lt;button class&#x3D;&quot;ms-CommandButton-button&quot;  &gt;
       &lt;span class&#x3D;&quot;ms-CommandButton-icon ms-fontColor-themePrimary&quot;&gt;&lt;i class&#x3D;&quot;ms-Icon ms-Icon--CircleRing&quot;&gt;&lt;/i&gt;&lt;/span&gt;&lt;span class&#x3D;&quot;ms-CommandButton-label&quot;&gt;&lt;/span&gt;  &lt;/button&gt;
 &lt;/div&gt;
     &lt;/div&gt;
   &lt;div class&#x3D;&quot;ms-CommandBar-mainArea&quot;&gt;
-      &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+      
 
 &lt;div class&#x3D;&quot;ms-SearchBox  ms-SearchBox--commandBar  &quot;&gt;
   &lt;input class&#x3D;&quot;ms-SearchBox-field&quot; type&#x3D;&quot;text&quot; value&#x3D;&quot;&quot;&gt;
@@ -59,33 +59,33 @@ State | Applied to | Result
     &lt;i class&#x3D;&quot;ms-SearchBox-icon ms-Icon ms-Icon--Search&quot;&gt;&lt;/i&gt;
     &lt;span class&#x3D;&quot;ms-SearchBox-text&quot;&gt;Search&lt;/span&gt;
   &lt;/label&gt;
-  &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+  
 &lt;div class&#x3D;&quot;ms-CommandButton ms-SearchBox-clear ms-CommandButton--noLabel  &quot;&gt;
   &lt;button class&#x3D;&quot;ms-CommandButton-button&quot;  &gt;
       &lt;span class&#x3D;&quot;ms-CommandButton-icon &quot;&gt;&lt;i class&#x3D;&quot;ms-Icon ms-Icon--Cancel&quot;&gt;&lt;/i&gt;&lt;/span&gt;&lt;span class&#x3D;&quot;ms-CommandButton-label&quot;&gt;&lt;/span&gt;  &lt;/button&gt;
 &lt;/div&gt;
-  &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+  
 &lt;div class&#x3D;&quot;ms-CommandButton ms-SearchBox-exit ms-CommandButton--noLabel  &quot;&gt;
   &lt;button class&#x3D;&quot;ms-CommandButton-button&quot;  &gt;
       &lt;span class&#x3D;&quot;ms-CommandButton-icon &quot;&gt;&lt;i class&#x3D;&quot;ms-Icon ms-Icon--ChromeBack&quot;&gt;&lt;/i&gt;&lt;/span&gt;&lt;span class&#x3D;&quot;ms-CommandButton-label&quot;&gt;&lt;/span&gt;  &lt;/button&gt;
 &lt;/div&gt;
-  &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+  
 &lt;div class&#x3D;&quot;ms-CommandButton ms-SearchBox-filter ms-CommandButton--noLabel  &quot;&gt;
   &lt;button class&#x3D;&quot;ms-CommandButton-button&quot;  &gt;
       &lt;span class&#x3D;&quot;ms-CommandButton-icon &quot;&gt;&lt;i class&#x3D;&quot;ms-Icon ms-Icon--Filter&quot;&gt;&lt;/i&gt;&lt;/span&gt;&lt;span class&#x3D;&quot;ms-CommandButton-label&quot;&gt;&lt;/span&gt;  &lt;/button&gt;
 &lt;/div&gt;
 &lt;/div&gt;
-      &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+      
 &lt;div class&#x3D;&quot;ms-CommandButton    &quot;&gt;
   &lt;button class&#x3D;&quot;ms-CommandButton-button&quot;  &gt;
       &lt;span class&#x3D;&quot;ms-CommandButton-icon ms-fontColor-themePrimary&quot;&gt;&lt;i class&#x3D;&quot;ms-Icon ms-Icon--CircleRing&quot;&gt;&lt;/i&gt;&lt;/span&gt;&lt;span class&#x3D;&quot;ms-CommandButton-label&quot;&gt;Command&lt;/span&gt;  &lt;/button&gt;
 &lt;/div&gt;
-      &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+      
 &lt;div class&#x3D;&quot;ms-CommandButton    &quot;&gt;
   &lt;button class&#x3D;&quot;ms-CommandButton-button&quot;  &gt;
       &lt;span class&#x3D;&quot;ms-CommandButton-icon ms-fontColor-themePrimary&quot;&gt;&lt;i class&#x3D;&quot;ms-Icon ms-Icon--CircleRing&quot;&gt;&lt;/i&gt;&lt;/span&gt;&lt;span class&#x3D;&quot;ms-CommandButton-label&quot;&gt;New&lt;/span&gt;&lt;span class&#x3D;&quot;ms-CommandButton-dropdownIcon&quot;&gt;&lt;i class&#x3D;&quot;ms-Icon ms-Icon--ChevronDown&quot;&gt;&lt;/i&gt;&lt;/span&gt;
   &lt;/button&gt;
-    &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+    
 &lt;ul class&#x3D;&quot;ms-ContextualMenu  is-opened ms-ContextualMenu--hasIcons&quot;&gt;
       &lt;li class&#x3D;&quot;ms-ContextualMenu-item &quot;&gt;
         &lt;a class&#x3D;&quot;ms-ContextualMenu-link &quot; tabindex&#x3D;&quot;1&quot; &gt;Folder&lt;/a&gt;
@@ -110,27 +110,27 @@ State | Applied to | Result
       &lt;/li&gt;
 &lt;/ul&gt;
 &lt;/div&gt;
-      &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+      
 &lt;div class&#x3D;&quot;ms-CommandButton    &quot;&gt;
   &lt;button class&#x3D;&quot;ms-CommandButton-button&quot;  &gt;
       &lt;span class&#x3D;&quot;ms-CommandButton-icon ms-fontColor-themePrimary&quot;&gt;&lt;i class&#x3D;&quot;ms-Icon ms-Icon--CircleRing&quot;&gt;&lt;/i&gt;&lt;/span&gt;&lt;span class&#x3D;&quot;ms-CommandButton-label&quot;&gt;Command&lt;/span&gt;  &lt;/button&gt;
 &lt;/div&gt;
-      &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+      
 &lt;div class&#x3D;&quot;ms-CommandButton    &quot;&gt;
   &lt;button class&#x3D;&quot;ms-CommandButton-button&quot;  &gt;
       &lt;span class&#x3D;&quot;ms-CommandButton-icon ms-fontColor-themePrimary&quot;&gt;&lt;i class&#x3D;&quot;ms-Icon ms-Icon--CircleRing&quot;&gt;&lt;/i&gt;&lt;/span&gt;&lt;span class&#x3D;&quot;ms-CommandButton-label&quot;&gt;Command&lt;/span&gt;  &lt;/button&gt;
 &lt;/div&gt;
-      &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+      
 &lt;div class&#x3D;&quot;ms-CommandButton    &quot;&gt;
   &lt;button class&#x3D;&quot;ms-CommandButton-button&quot;  &gt;
       &lt;span class&#x3D;&quot;ms-CommandButton-icon ms-fontColor-themePrimary&quot;&gt;&lt;i class&#x3D;&quot;ms-Icon ms-Icon--CircleRing&quot;&gt;&lt;/i&gt;&lt;/span&gt;&lt;span class&#x3D;&quot;ms-CommandButton-label&quot;&gt;Command&lt;/span&gt;  &lt;/button&gt;
 &lt;/div&gt;
-      &lt;!-- Overflow Command --&gt;
-        &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+      
+        
 &lt;div class&#x3D;&quot;ms-CommandButton ms-CommandBar-overflowButton ms-CommandButton--noLabel  &quot;&gt;
   &lt;button class&#x3D;&quot;ms-CommandButton-button&quot;  &gt;
       &lt;span class&#x3D;&quot;ms-CommandButton-icon &quot;&gt;&lt;i class&#x3D;&quot;ms-Icon ms-Icon--More&quot;&gt;&lt;/i&gt;&lt;/span&gt;&lt;span class&#x3D;&quot;ms-CommandButton-label&quot;&gt;&lt;/span&gt;  &lt;/button&gt;
-    &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+    
 &lt;ul class&#x3D;&quot;ms-ContextualMenu  is-opened ms-ContextualMenu--hasIcons&quot;&gt;
       &lt;li class&#x3D;&quot;ms-ContextualMenu-item &quot;&gt;
         &lt;a class&#x3D;&quot;ms-ContextualMenu-link &quot; tabindex&#x3D;&quot;1&quot; &gt;Folder&lt;/a&gt;
@@ -155,7 +155,7 @@ State | Applied to | Result
       &lt;/li&gt;
 &lt;/ul&gt;
 &lt;/div&gt;
-      &lt;!-- End Overflow Command --&gt;
+      
   &lt;/div&gt;
 &lt;/div&gt;
     </code>

--- a/ghdocs/components/CommandButton.md
+++ b/ghdocs/components/CommandButton.md
@@ -81,10 +81,10 @@ State | Applied to | Result
 
 <pre>
     <code>
- &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+ 
 &lt;div class&#x3D;&quot;ms-CommandButton    &quot;&gt;
   &lt;button class&#x3D;&quot;ms-CommandButton-button&quot;  &gt;
-      &lt;span class&#x3D;&quot;ms-CommandButton-icon ms-fontColor-themePrimary&quot;&gt;&lt;i class&#x3D;&quot;ms-Icon ms-Icon--CircleFill&quot;&gt;&lt;/i&gt;&lt;/span&gt;&lt;span class&#x3D;&quot;ms-CommandButton-label&quot;&gt;Command&lt;/span&gt;  &lt;/button&gt;
+      &lt;span class&#x3D;&quot;ms-CommandButton-icon ms-fontColor-themePrimary&quot;&gt;&lt;i class&#x3D;&quot;ms-Icon ms-Icon--CircleRing&quot;&gt;&lt;/i&gt;&lt;/span&gt;&lt;span class&#x3D;&quot;ms-CommandButton-label&quot;&gt;Command&lt;/span&gt;  &lt;/button&gt;
 &lt;/div&gt;
     </code>
 </pre>

--- a/ghdocs/components/ContextualMenu.md
+++ b/ghdocs/components/ContextualMenu.md
@@ -59,12 +59,12 @@ State | Applied to | Result
 <pre>
     <code>
  &lt;div class&#x3D;&quot;ms-ContextualMenu-basic&quot;&gt;
-    &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+    
     &lt;button class&#x3D;&quot;ms-Button 
       ms-Button--primary
       &quot;&gt;
       &lt;span class&#x3D;&quot;ms-Button-label&quot;&gt;Open Example&lt;/span&gt;
-    &lt;/button&gt;    &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+    &lt;/button&gt;    
     &lt;ul class&#x3D;&quot;ms-ContextualMenu  is-hidden &quot;&gt;
           &lt;li class&#x3D;&quot;ms-ContextualMenu-item &quot;&gt;
             &lt;a class&#x3D;&quot;ms-ContextualMenu-link &quot; tabindex&#x3D;&quot;1&quot; &gt;Animals&lt;/a&gt;

--- a/ghdocs/components/DatePicker.md
+++ b/ghdocs/components/DatePicker.md
@@ -31,8 +31,8 @@ State | Applied to | Result
 
 <pre>
     <code>
- &lt;!-- This is a sample Date Picker that works for Gregorian calendars. It uses jQuery and pickadate.js for demonstration. --&gt;
-&lt;!-- For more information on this version of pickadate.js (3.5.3), go here: https://github.com/amsul/pickadate.js/tree/505e00b9208a81ffb169338042c0b9c781e76fb7 --&gt;
+ 
+
 
 &lt;div class&#x3D;&quot;ms-DatePicker&quot;&gt;
   &lt;div class&#x3D;&quot;ms-TextField&quot;&gt;

--- a/ghdocs/components/Dialog.md
+++ b/ghdocs/components/Dialog.md
@@ -60,12 +60,12 @@ This component has only the default state.
 
 <pre>
     <code>
- &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+ 
 &lt;div class&#x3D;&quot;ms-Dialog &quot;&gt;
     &lt;div class&#x3D;&quot;ms-Dialog-title&quot;&gt;All emails together&lt;/div&gt;
     &lt;div class&#x3D;&quot;ms-Dialog-content&quot;&gt;
         &lt;p class&#x3D;&quot;ms-Dialog-subText&quot;&gt;Your Inbox has changed. No longer does it include favorites, it is a singular destination for your emails.&lt;/p&gt;
-          &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+          
 
 &lt;div class&#x3D;&quot;ms-CheckBox&quot;&gt; 
     &lt;input tabindex&#x3D;&quot;-1&quot; type&#x3D;&quot;checkbox&quot; class&#x3D;&quot;ms-CheckBox-input&quot;&gt;
@@ -79,7 +79,7 @@ This component has only the default state.
     &lt;/label&gt;
 &lt;/div&gt;
 
-          &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+          
 
 &lt;div class&#x3D;&quot;ms-CheckBox&quot;&gt; 
     &lt;input tabindex&#x3D;&quot;-1&quot; type&#x3D;&quot;checkbox&quot; class&#x3D;&quot;ms-CheckBox-input&quot;&gt;
@@ -95,13 +95,13 @@ This component has only the default state.
 
     &lt;/div&gt;
       &lt;div class&#x3D;&quot;ms-Dialog-actions&quot;&gt;
-          &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+          
 &lt;button class&#x3D;&quot;ms-Button ms-Dialog-action
   ms-Button--primary
   &quot;&gt;
   &lt;span class&#x3D;&quot;ms-Button-label&quot;&gt;Save&lt;/span&gt;
 &lt;/button&gt;
-          &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+          
 &lt;button class&#x3D;&quot;ms-Button ms-Dialog-action
   
   &quot;&gt;

--- a/ghdocs/components/Dropdown.md
+++ b/ghdocs/components/Dropdown.md
@@ -33,9 +33,9 @@ State | Applied to | Result
 
 <pre>
     <code>
- &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+ 
 
-&lt;!-- Future implementation to be discussed --&gt;
+
 &lt;div class&#x3D;&quot;ms-Dropdown  &quot; tabindex&#x3D;&quot;0&quot;&gt;
   &lt;label class&#x3D;&quot;ms-Label&quot;&gt;Dropdown label&lt;/label&gt;
   &lt;i class&#x3D;&quot;ms-Dropdown-caretDown ms-Icon ms-Icon--ChevronDown&quot;&gt;&lt;/i&gt;

--- a/ghdocs/components/FacePile.md
+++ b/ghdocs/components/FacePile.md
@@ -28,14 +28,14 @@ State | Applied to | Result
 
 <pre>
     <code>
- &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+ 
 
 &lt;div class&#x3D;&quot;ms-FacePile&quot;&gt;
   &lt;button class&#x3D;&quot;ms-FacePile-addButton ms-FacePile-addButton--addPerson&quot;&gt;
     &lt;i class&#x3D;&quot;ms-FacePile-addPersonIcon ms-Icon ms-Icon--AddFriend&quot;&gt;&lt;/i&gt;
   &lt;/button&gt;
   
-      &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+      
       
       &lt;div class&#x3D;&quot;ms-Persona
             ms-Persona--facePile
@@ -50,10 +50,10 @@ State | Applied to | Result
             &lt;div class&#x3D;&quot;ms-Persona-primaryText&quot;&gt;Alton Lafferty&lt;/div&gt;
             &lt;div class&#x3D;&quot;ms-Persona-secondaryText&quot;&gt;Accountant&lt;/div&gt;
         &lt;/div&gt;
-          &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+          
           &lt;div class&#x3D;&quot;ms-PersonaCard &quot;&gt;
             &lt;div class&#x3D;&quot;ms-PersonaCard-persona&quot;&gt;
-              &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+              
               
               &lt;div class&#x3D;&quot;ms-Persona
                     ms-Persona--lg
@@ -97,9 +97,9 @@ State | Applied to | Result
               &lt;div data-detail-id&#x3D;&quot;video&quot; class&#x3D;&quot;ms-PersonaCard-details&quot;&gt;
                 &lt;div class&#x3D;&quot;ms-PersonaCard-detailLine&quot;&gt;&lt;span class&#x3D;&quot;ms-PersonaCard-detailLabel&quot;&gt;Skype:&lt;/span&gt; &lt;a class&#x3D;&quot;ms-Link&quot; href&#x3D;&quot;#&quot;&gt;Start Skype call&lt;/a&gt;&lt;/div&gt;
               &lt;/div&gt;
-                &lt;!-- org chart --&gt;
+                
               &lt;div data-detail-id&#x3D;&quot;org&quot; class&#x3D;&quot;ms-PersonaCard-details&quot;&gt;
-                &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+                
                 
                 &lt;div class&#x3D;&quot;ms-OrgChart &quot;&gt;
                     &lt;div class&#x3D;&quot;ms-OrgChart-group&quot;&gt;
@@ -107,7 +107,7 @@ State | Applied to | Result
                       &lt;ul class&#x3D;&quot;ms-OrgChart-list&quot;&gt;
                           &lt;li class&#x3D;&quot;ms-OrgChart-listItem&quot;&gt;
                             &lt;button class&#x3D;&quot;ms-OrgChart-listItemBtn&quot; tabindex&#x3D;&quot;1&quot;&gt;
-                              &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+                              
                 
                 &lt;div class&#x3D;&quot;ms-Persona
                 &quot;&gt;
@@ -127,7 +127,7 @@ State | Applied to | Result
                           &lt;/li&gt;
                           &lt;li class&#x3D;&quot;ms-OrgChart-listItem&quot;&gt;
                             &lt;button class&#x3D;&quot;ms-OrgChart-listItemBtn&quot; tabindex&#x3D;&quot;1&quot;&gt;
-                              &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+                              
                 
                 &lt;div class&#x3D;&quot;ms-Persona
                 &quot;&gt;
@@ -152,7 +152,7 @@ State | Applied to | Result
                       &lt;ul class&#x3D;&quot;ms-OrgChart-list&quot;&gt;
                           &lt;li class&#x3D;&quot;ms-OrgChart-listItem&quot;&gt;
                             &lt;button class&#x3D;&quot;ms-OrgChart-listItemBtn&quot; tabindex&#x3D;&quot;1&quot;&gt;
-                              &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+                              
                 
                 &lt;div class&#x3D;&quot;ms-Persona
                 &quot;&gt;
@@ -177,7 +177,7 @@ State | Applied to | Result
                       &lt;ul class&#x3D;&quot;ms-OrgChart-list&quot;&gt;
                           &lt;li class&#x3D;&quot;ms-OrgChart-listItem&quot;&gt;
                             &lt;button class&#x3D;&quot;ms-OrgChart-listItemBtn&quot; tabindex&#x3D;&quot;1&quot;&gt;
-                              &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+                              
                 
                 &lt;div class&#x3D;&quot;ms-Persona
                 &quot;&gt;
@@ -197,7 +197,7 @@ State | Applied to | Result
                           &lt;/li&gt;
                           &lt;li class&#x3D;&quot;ms-OrgChart-listItem&quot;&gt;
                             &lt;button class&#x3D;&quot;ms-OrgChart-listItemBtn&quot; tabindex&#x3D;&quot;1&quot;&gt;
-                              &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+                              
                 
                 &lt;div class&#x3D;&quot;ms-Persona
                 &quot;&gt;
@@ -217,7 +217,7 @@ State | Applied to | Result
                           &lt;/li&gt;
                           &lt;li class&#x3D;&quot;ms-OrgChart-listItem&quot;&gt;
                             &lt;button class&#x3D;&quot;ms-OrgChart-listItemBtn&quot; tabindex&#x3D;&quot;1&quot;&gt;
-                              &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+                              
                 
                 &lt;div class&#x3D;&quot;ms-Persona
                 &quot;&gt;
@@ -237,7 +237,7 @@ State | Applied to | Result
                           &lt;/li&gt;
                           &lt;li class&#x3D;&quot;ms-OrgChart-listItem&quot;&gt;
                             &lt;button class&#x3D;&quot;ms-OrgChart-listItemBtn&quot; tabindex&#x3D;&quot;1&quot;&gt;
-                              &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+                              
                 
                 &lt;div class&#x3D;&quot;ms-Persona
                 &quot;&gt;
@@ -261,7 +261,7 @@ State | Applied to | Result
             &lt;/div&gt;
           &lt;/div&gt;
       &lt;/div&gt;
-      &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+      
       
       &lt;div class&#x3D;&quot;ms-Persona
             ms-Persona--facePile
@@ -275,10 +275,10 @@ State | Applied to | Result
             &lt;div class&#x3D;&quot;ms-Persona-primaryText&quot;&gt;Marcus Lauer&lt;/div&gt;
             &lt;div class&#x3D;&quot;ms-Persona-secondaryText&quot;&gt;Accountant&lt;/div&gt;
         &lt;/div&gt;
-          &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+          
           &lt;div class&#x3D;&quot;ms-PersonaCard &quot;&gt;
             &lt;div class&#x3D;&quot;ms-PersonaCard-persona&quot;&gt;
-              &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+              
               
               &lt;div class&#x3D;&quot;ms-Persona
                     ms-Persona--lg
@@ -321,9 +321,9 @@ State | Applied to | Result
               &lt;div data-detail-id&#x3D;&quot;video&quot; class&#x3D;&quot;ms-PersonaCard-details&quot;&gt;
                 &lt;div class&#x3D;&quot;ms-PersonaCard-detailLine&quot;&gt;&lt;span class&#x3D;&quot;ms-PersonaCard-detailLabel&quot;&gt;Skype:&lt;/span&gt; &lt;a class&#x3D;&quot;ms-Link&quot; href&#x3D;&quot;#&quot;&gt;Start Skype call&lt;/a&gt;&lt;/div&gt;
               &lt;/div&gt;
-                &lt;!-- org chart --&gt;
+                
               &lt;div data-detail-id&#x3D;&quot;org&quot; class&#x3D;&quot;ms-PersonaCard-details&quot;&gt;
-                &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+                
                 
                 &lt;div class&#x3D;&quot;ms-OrgChart &quot;&gt;
                     &lt;div class&#x3D;&quot;ms-OrgChart-group&quot;&gt;
@@ -331,7 +331,7 @@ State | Applied to | Result
                       &lt;ul class&#x3D;&quot;ms-OrgChart-list&quot;&gt;
                           &lt;li class&#x3D;&quot;ms-OrgChart-listItem&quot;&gt;
                             &lt;button class&#x3D;&quot;ms-OrgChart-listItemBtn&quot; tabindex&#x3D;&quot;1&quot;&gt;
-                              &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+                              
                 
                 &lt;div class&#x3D;&quot;ms-Persona
                 &quot;&gt;
@@ -351,7 +351,7 @@ State | Applied to | Result
                           &lt;/li&gt;
                           &lt;li class&#x3D;&quot;ms-OrgChart-listItem&quot;&gt;
                             &lt;button class&#x3D;&quot;ms-OrgChart-listItemBtn&quot; tabindex&#x3D;&quot;1&quot;&gt;
-                              &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+                              
                 
                 &lt;div class&#x3D;&quot;ms-Persona
                 &quot;&gt;
@@ -376,7 +376,7 @@ State | Applied to | Result
                       &lt;ul class&#x3D;&quot;ms-OrgChart-list&quot;&gt;
                           &lt;li class&#x3D;&quot;ms-OrgChart-listItem&quot;&gt;
                             &lt;button class&#x3D;&quot;ms-OrgChart-listItemBtn&quot; tabindex&#x3D;&quot;1&quot;&gt;
-                              &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+                              
                 
                 &lt;div class&#x3D;&quot;ms-Persona
                 &quot;&gt;
@@ -401,7 +401,7 @@ State | Applied to | Result
                       &lt;ul class&#x3D;&quot;ms-OrgChart-list&quot;&gt;
                           &lt;li class&#x3D;&quot;ms-OrgChart-listItem&quot;&gt;
                             &lt;button class&#x3D;&quot;ms-OrgChart-listItemBtn&quot; tabindex&#x3D;&quot;1&quot;&gt;
-                              &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+                              
                 
                 &lt;div class&#x3D;&quot;ms-Persona
                 &quot;&gt;
@@ -421,7 +421,7 @@ State | Applied to | Result
                           &lt;/li&gt;
                           &lt;li class&#x3D;&quot;ms-OrgChart-listItem&quot;&gt;
                             &lt;button class&#x3D;&quot;ms-OrgChart-listItemBtn&quot; tabindex&#x3D;&quot;1&quot;&gt;
-                              &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+                              
                 
                 &lt;div class&#x3D;&quot;ms-Persona
                 &quot;&gt;
@@ -441,7 +441,7 @@ State | Applied to | Result
                           &lt;/li&gt;
                           &lt;li class&#x3D;&quot;ms-OrgChart-listItem&quot;&gt;
                             &lt;button class&#x3D;&quot;ms-OrgChart-listItemBtn&quot; tabindex&#x3D;&quot;1&quot;&gt;
-                              &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+                              
                 
                 &lt;div class&#x3D;&quot;ms-Persona
                 &quot;&gt;
@@ -461,7 +461,7 @@ State | Applied to | Result
                           &lt;/li&gt;
                           &lt;li class&#x3D;&quot;ms-OrgChart-listItem&quot;&gt;
                             &lt;button class&#x3D;&quot;ms-OrgChart-listItemBtn&quot; tabindex&#x3D;&quot;1&quot;&gt;
-                              &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+                              
                 
                 &lt;div class&#x3D;&quot;ms-Persona
                 &quot;&gt;
@@ -485,7 +485,7 @@ State | Applied to | Result
             &lt;/div&gt;
           &lt;/div&gt;
       &lt;/div&gt;
-      &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+      
       
       &lt;div class&#x3D;&quot;ms-Persona
             ms-Persona--facePile
@@ -499,10 +499,10 @@ State | Applied to | Result
             &lt;div class&#x3D;&quot;ms-Persona-primaryText&quot;&gt;Douglas Fielder&lt;/div&gt;
             &lt;div class&#x3D;&quot;ms-Persona-secondaryText&quot;&gt;Accountant&lt;/div&gt;
         &lt;/div&gt;
-          &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+          
           &lt;div class&#x3D;&quot;ms-PersonaCard &quot;&gt;
             &lt;div class&#x3D;&quot;ms-PersonaCard-persona&quot;&gt;
-              &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+              
               
               &lt;div class&#x3D;&quot;ms-Persona
                     ms-Persona--lg
@@ -545,9 +545,9 @@ State | Applied to | Result
               &lt;div data-detail-id&#x3D;&quot;video&quot; class&#x3D;&quot;ms-PersonaCard-details&quot;&gt;
                 &lt;div class&#x3D;&quot;ms-PersonaCard-detailLine&quot;&gt;&lt;span class&#x3D;&quot;ms-PersonaCard-detailLabel&quot;&gt;Skype:&lt;/span&gt; &lt;a class&#x3D;&quot;ms-Link&quot; href&#x3D;&quot;#&quot;&gt;Start Skype call&lt;/a&gt;&lt;/div&gt;
               &lt;/div&gt;
-                &lt;!-- org chart --&gt;
+                
               &lt;div data-detail-id&#x3D;&quot;org&quot; class&#x3D;&quot;ms-PersonaCard-details&quot;&gt;
-                &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+                
                 
                 &lt;div class&#x3D;&quot;ms-OrgChart &quot;&gt;
                     &lt;div class&#x3D;&quot;ms-OrgChart-group&quot;&gt;
@@ -555,7 +555,7 @@ State | Applied to | Result
                       &lt;ul class&#x3D;&quot;ms-OrgChart-list&quot;&gt;
                           &lt;li class&#x3D;&quot;ms-OrgChart-listItem&quot;&gt;
                             &lt;button class&#x3D;&quot;ms-OrgChart-listItemBtn&quot; tabindex&#x3D;&quot;1&quot;&gt;
-                              &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+                              
                 
                 &lt;div class&#x3D;&quot;ms-Persona
                 &quot;&gt;
@@ -575,7 +575,7 @@ State | Applied to | Result
                           &lt;/li&gt;
                           &lt;li class&#x3D;&quot;ms-OrgChart-listItem&quot;&gt;
                             &lt;button class&#x3D;&quot;ms-OrgChart-listItemBtn&quot; tabindex&#x3D;&quot;1&quot;&gt;
-                              &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+                              
                 
                 &lt;div class&#x3D;&quot;ms-Persona
                 &quot;&gt;
@@ -600,7 +600,7 @@ State | Applied to | Result
                       &lt;ul class&#x3D;&quot;ms-OrgChart-list&quot;&gt;
                           &lt;li class&#x3D;&quot;ms-OrgChart-listItem&quot;&gt;
                             &lt;button class&#x3D;&quot;ms-OrgChart-listItemBtn&quot; tabindex&#x3D;&quot;1&quot;&gt;
-                              &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+                              
                 
                 &lt;div class&#x3D;&quot;ms-Persona
                 &quot;&gt;
@@ -625,7 +625,7 @@ State | Applied to | Result
                       &lt;ul class&#x3D;&quot;ms-OrgChart-list&quot;&gt;
                           &lt;li class&#x3D;&quot;ms-OrgChart-listItem&quot;&gt;
                             &lt;button class&#x3D;&quot;ms-OrgChart-listItemBtn&quot; tabindex&#x3D;&quot;1&quot;&gt;
-                              &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+                              
                 
                 &lt;div class&#x3D;&quot;ms-Persona
                 &quot;&gt;
@@ -645,7 +645,7 @@ State | Applied to | Result
                           &lt;/li&gt;
                           &lt;li class&#x3D;&quot;ms-OrgChart-listItem&quot;&gt;
                             &lt;button class&#x3D;&quot;ms-OrgChart-listItemBtn&quot; tabindex&#x3D;&quot;1&quot;&gt;
-                              &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+                              
                 
                 &lt;div class&#x3D;&quot;ms-Persona
                 &quot;&gt;
@@ -665,7 +665,7 @@ State | Applied to | Result
                           &lt;/li&gt;
                           &lt;li class&#x3D;&quot;ms-OrgChart-listItem&quot;&gt;
                             &lt;button class&#x3D;&quot;ms-OrgChart-listItemBtn&quot; tabindex&#x3D;&quot;1&quot;&gt;
-                              &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+                              
                 
                 &lt;div class&#x3D;&quot;ms-Persona
                 &quot;&gt;
@@ -685,7 +685,7 @@ State | Applied to | Result
                           &lt;/li&gt;
                           &lt;li class&#x3D;&quot;ms-OrgChart-listItem&quot;&gt;
                             &lt;button class&#x3D;&quot;ms-OrgChart-listItemBtn&quot; tabindex&#x3D;&quot;1&quot;&gt;
-                              &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+                              
                 
                 &lt;div class&#x3D;&quot;ms-Persona
                 &quot;&gt;

--- a/ghdocs/components/Label.md
+++ b/ghdocs/components/Label.md
@@ -39,7 +39,7 @@ State | Applied to | Result
 
 <pre>
     <code>
- &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+ 
 &lt;label class&#x3D;&quot;ms-Label  &quot;&gt;Name&lt;/label&gt;
 
     </code>

--- a/ghdocs/components/Link.md
+++ b/ghdocs/components/Link.md
@@ -25,7 +25,7 @@ This component has only the default state.
 <pre>
     <code>
  &lt;div class&#x3D;&quot;ms-font-m&quot;&gt;
-    &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+    
     
     &lt;a class&#x3D;&quot;ms-Link  &quot; 
        href&#x3D;&quot;#&quot;  

--- a/ghdocs/components/List.md
+++ b/ghdocs/components/List.md
@@ -27,10 +27,10 @@ This component has only the default state.
 
 <pre>
     <code>
- &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+ 
 
 &lt;ul class&#x3D;&quot;ms-List &quot;&gt;
-    &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+    
     
     &lt;li class&#x3D;&quot;ms-ListItem  is-unread is-selectable&quot; tabindex&#x3D;&quot;0&quot;&gt;
       
@@ -49,7 +49,7 @@ This component has only the default state.
       &lt;/div&gt;
     &lt;/li&gt;
     
-    &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+    
     
     &lt;li class&#x3D;&quot;ms-ListItem  is-unread is-selectable&quot; tabindex&#x3D;&quot;0&quot;&gt;
       
@@ -68,7 +68,7 @@ This component has only the default state.
       &lt;/div&gt;
     &lt;/li&gt;
     
-    &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+    
     
     &lt;li class&#x3D;&quot;ms-ListItem  is-unread is-selectable&quot; tabindex&#x3D;&quot;0&quot;&gt;
       
@@ -87,7 +87,7 @@ This component has only the default state.
       &lt;/div&gt;
     &lt;/li&gt;
     
-    &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+    
     
     &lt;li class&#x3D;&quot;ms-ListItem  is-unread is-selectable&quot; tabindex&#x3D;&quot;0&quot;&gt;
       
@@ -106,7 +106,7 @@ This component has only the default state.
       &lt;/div&gt;
     &lt;/li&gt;
     
-    &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+    
     
     &lt;li class&#x3D;&quot;ms-ListItem  is-unread is-selectable&quot; tabindex&#x3D;&quot;0&quot;&gt;
       
@@ -125,7 +125,7 @@ This component has only the default state.
       &lt;/div&gt;
     &lt;/li&gt;
     
-    &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+    
     
     &lt;li class&#x3D;&quot;ms-ListItem  is-selectable&quot; tabindex&#x3D;&quot;0&quot;&gt;
       
@@ -144,7 +144,7 @@ This component has only the default state.
       &lt;/div&gt;
     &lt;/li&gt;
     
-    &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+    
     
     &lt;li class&#x3D;&quot;ms-ListItem  is-selectable&quot; tabindex&#x3D;&quot;0&quot;&gt;
       
@@ -163,7 +163,7 @@ This component has only the default state.
       &lt;/div&gt;
     &lt;/li&gt;
     
-    &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+    
     
     &lt;li class&#x3D;&quot;ms-ListItem  is-selectable&quot; tabindex&#x3D;&quot;0&quot;&gt;
       

--- a/ghdocs/components/ListItem.md
+++ b/ghdocs/components/ListItem.md
@@ -51,7 +51,7 @@ Use `is-unread` to indicate that the item has not been read.
 
 <pre>
     <code>
- &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+ 
 
 &lt;li class&#x3D;&quot;ms-ListItem  &quot; tabindex&#x3D;&quot;0&quot;&gt;
   

--- a/ghdocs/components/MessageBanner.md
+++ b/ghdocs/components/MessageBanner.md
@@ -26,7 +26,7 @@ This component has only the default state.
 <pre>
     <code>
  &lt;div class&#x3D;&quot;docs-MessageBannerExample&quot;&gt;
-  &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+  
   
   &lt;div class&#x3D;&quot;ms-MessageBanner&quot;&gt;
     &lt;div class&#x3D;&quot;ms-MessageBanner-content&quot;&gt;
@@ -39,7 +39,7 @@ This component has only the default state.
         &lt;i class&#x3D;&quot;ms-Icon ms-Icon--ChevronDown&quot;&gt;&lt;/i&gt;
       &lt;/button&gt;
       &lt;div class&#x3D;&quot;ms-MessageBanner-action&quot;&gt;
-        &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+        
   &lt;button class&#x3D;&quot;ms-Button 
     ms-Button--primary
     &quot;&gt;
@@ -51,7 +51,7 @@ This component has only the default state.
       &lt;i class&#x3D;&quot;ms-Icon ms-Icon--Clear&quot;&gt;&lt;/i&gt;
     &lt;/button&gt;
   &lt;/div&gt;
-  &lt;button class&#x3D;&quot;ms-Button docs-MessageBannerExample-button&quot;&gt;Show the banner&lt;/button&gt;
+  &lt;button class&#x3D;&quot;ms-Button docs-MessageBannerExample-button is-hidden&quot;&gt;Show the banner&lt;/button&gt;
 &lt;/div&gt;
     </code>
 </pre>
@@ -64,11 +64,20 @@ This component has only the default state.
   var MessageBannerExample &#x3D; document.querySelector(&#x27;.docs-MessageBannerExample&#x27;);
   var MessageBanner &#x3D; new fabric[&#x27;MessageBanner&#x27;](MessageBannerExample.querySelector(&#x27;.ms-MessageBanner&#x27;));
   var MessageBannerButton &#x3D; MessageBannerExample.querySelector(&#x27;.docs-MessageBannerExample-button&#x27;);
-  
+  var MessageBannerCloseButton &#x3D; MessageBannerExample.querySelector(&#x27;.ms-MessageBanner-close&#x27;);
+
   // When clicking the button, open the MessageBanner
   MessageBannerButton.onclick &#x3D; function() {
     MessageBanner.showBanner();
+    this.classList.add(&quot;is-hidden&quot;);
   };
+
+  // Hide &quot;Show the Banner Button&quot; when banner is active
+  MessageBannerCloseButton.addEventListener(&quot;click&quot;, function(){
+  	setTimeout(function() {
+  		MessageBannerButton.classList.remove(&quot;is-hidden&quot;);
+  	}, 500);
+  });
 &lt;/script&gt;
     </code>
 </pre>
@@ -84,9 +93,18 @@ This component has a dependency on Button.
   var MessageBannerExample = document.querySelector('.docs-MessageBannerExample');
   var MessageBanner = new fabric['MessageBanner'](MessageBannerExample.querySelector('.ms-MessageBanner'));
   var MessageBannerButton = MessageBannerExample.querySelector('.docs-MessageBannerExample-button');
-  
+  var MessageBannerCloseButton = MessageBannerExample.querySelector('.ms-MessageBanner-close');
+
   // When clicking the button, open the MessageBanner
   MessageBannerButton.onclick = function() {
     MessageBanner.showBanner();
+    this.classList.add("is-hidden");
   };
+
+  // Hide "Show the Banner Button" when banner is active
+  MessageBannerCloseButton.addEventListener("click", function(){
+  	setTimeout(function() {
+  		MessageBannerButton.classList.remove("is-hidden");
+  	}, 500);
+  });
 </script>

--- a/ghdocs/components/MessageBar.md
+++ b/ghdocs/components/MessageBar.md
@@ -46,6 +46,7 @@ Use when the user is explicitly forbidden from a particular action not because o
 Use sparingly when there's an exceptional need to tell the use that something went right. The preferred way to show success is to show, not tell (e.g. by navigating to show the result of the user action and letting users continue working on it or elsewhere).
 
 
+<!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. -->
 
 <div class="ms-MessageBar ms-MessageBar--success">
   <div class="ms-MessageBar-content">
@@ -75,7 +76,7 @@ Use sparingly when there's an exceptional need to tell the use that something we
 
 <pre>
     <code>
- &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+ 
 
 &lt;div class&#x3D;&quot;ms-MessageBar &quot;&gt;
   &lt;div class&#x3D;&quot;ms-MessageBar-content&quot;&gt;

--- a/ghdocs/components/MessageBar.md
+++ b/ghdocs/components/MessageBar.md
@@ -46,20 +46,6 @@ Use when the user is explicitly forbidden from a particular action not because o
 Use sparingly when there's an exceptional need to tell the use that something went right. The preferred way to show success is to show, not tell (e.g. by navigating to show the result of the user action and letting users continue working on it or elsewhere).
 
 
-<!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. -->
-
-<div class="ms-MessageBar ms-MessageBar--success">
-  <div class="ms-MessageBar-content">
-    <div class="ms-MessageBar-icon">
-      <i class="ms-Icon ms-Icon--Completed"></i>
-    </div>
-    <div class="ms-MessageBar-text">
-      Lorem ipsum dolor sit amet, a elit sem interdum consectetur adipiscing elit.<br>
-      <a href="" class="ms-Link">Hyperlink string</a>
-    </div>
-  </div>
-</div>
-
 
 ![MessageBar example](https://raw.githubusercontent.com/OfficeDev/office-ui-fabric-js/master/ghdocs/component_images/MessageBar-success.png)
 

--- a/ghdocs/components/OrgChart.md
+++ b/ghdocs/components/OrgChart.md
@@ -22,7 +22,7 @@ Displays multiple Persona components in groups with headers in order to show the
 
 <pre>
     <code>
- &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+ 
 
 &lt;div class&#x3D;&quot;ms-OrgChart &quot;&gt;
     &lt;div class&#x3D;&quot;ms-OrgChart-group&quot;&gt;
@@ -30,7 +30,7 @@ Displays multiple Persona components in groups with headers in order to show the
       &lt;ul class&#x3D;&quot;ms-OrgChart-list&quot;&gt;
           &lt;li class&#x3D;&quot;ms-OrgChart-listItem&quot;&gt;
             &lt;button class&#x3D;&quot;ms-OrgChart-listItemBtn&quot; tabindex&#x3D;&quot;1&quot;&gt;
-              &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+              
 
 &lt;div class&#x3D;&quot;ms-Persona
 &quot;&gt;
@@ -50,7 +50,7 @@ Displays multiple Persona components in groups with headers in order to show the
           &lt;/li&gt;
           &lt;li class&#x3D;&quot;ms-OrgChart-listItem&quot;&gt;
             &lt;button class&#x3D;&quot;ms-OrgChart-listItemBtn&quot; tabindex&#x3D;&quot;1&quot;&gt;
-              &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+              
 
 &lt;div class&#x3D;&quot;ms-Persona
 &quot;&gt;
@@ -75,7 +75,7 @@ Displays multiple Persona components in groups with headers in order to show the
       &lt;ul class&#x3D;&quot;ms-OrgChart-list&quot;&gt;
           &lt;li class&#x3D;&quot;ms-OrgChart-listItem&quot;&gt;
             &lt;button class&#x3D;&quot;ms-OrgChart-listItemBtn&quot; tabindex&#x3D;&quot;1&quot;&gt;
-              &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+              
 
 &lt;div class&#x3D;&quot;ms-Persona
 &quot;&gt;
@@ -100,7 +100,7 @@ Displays multiple Persona components in groups with headers in order to show the
       &lt;ul class&#x3D;&quot;ms-OrgChart-list&quot;&gt;
           &lt;li class&#x3D;&quot;ms-OrgChart-listItem&quot;&gt;
             &lt;button class&#x3D;&quot;ms-OrgChart-listItemBtn&quot; tabindex&#x3D;&quot;1&quot;&gt;
-              &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+              
 
 &lt;div class&#x3D;&quot;ms-Persona
 &quot;&gt;
@@ -120,7 +120,7 @@ Displays multiple Persona components in groups with headers in order to show the
           &lt;/li&gt;
           &lt;li class&#x3D;&quot;ms-OrgChart-listItem&quot;&gt;
             &lt;button class&#x3D;&quot;ms-OrgChart-listItemBtn&quot; tabindex&#x3D;&quot;1&quot;&gt;
-              &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+              
 
 &lt;div class&#x3D;&quot;ms-Persona
 &quot;&gt;
@@ -140,7 +140,7 @@ Displays multiple Persona components in groups with headers in order to show the
           &lt;/li&gt;
           &lt;li class&#x3D;&quot;ms-OrgChart-listItem&quot;&gt;
             &lt;button class&#x3D;&quot;ms-OrgChart-listItemBtn&quot; tabindex&#x3D;&quot;1&quot;&gt;
-              &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+              
 
 &lt;div class&#x3D;&quot;ms-Persona
 &quot;&gt;
@@ -160,7 +160,7 @@ Displays multiple Persona components in groups with headers in order to show the
           &lt;/li&gt;
           &lt;li class&#x3D;&quot;ms-OrgChart-listItem&quot;&gt;
             &lt;button class&#x3D;&quot;ms-OrgChart-listItemBtn&quot; tabindex&#x3D;&quot;1&quot;&gt;
-              &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+              
 
 &lt;div class&#x3D;&quot;ms-Persona
 &quot;&gt;

--- a/ghdocs/components/Panel.md
+++ b/ghdocs/components/Panel.md
@@ -53,12 +53,12 @@ State | Applied to | Result
 <pre>
     <code>
  &lt;div class&#x3D;&quot;ms-PanelDefaultExample ms-PanelExample&quot;&gt;
-    &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+    
     &lt;button class&#x3D;&quot;ms-Button 
       
       &quot;&gt;
       &lt;span class&#x3D;&quot;ms-Button-label&quot;&gt;Open Panel&lt;/span&gt;
-    &lt;/button&gt;    &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+    &lt;/button&gt;    
     &lt;div class&#x3D;&quot;ms-Panel &quot;&gt;
         &lt;button class&#x3D;&quot;ms-Panel-closeButton ms-PanelAction-close&quot;&gt;
             &lt;i class&#x3D;&quot;ms-Panel-closeIcon ms-Icon ms-Icon--Cancel&quot;&gt;&lt;/i&gt;

--- a/ghdocs/components/PeoplePicker.md
+++ b/ghdocs/components/PeoplePicker.md
@@ -38,12 +38,12 @@ Presents the selected people in a list below the search field, rather than inlin
 
 <pre>
     <code>
- &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+ 
 
 &lt;div class&#x3D;&quot;ms-PeoplePicker
 &quot;&gt;
   &lt;div class&#x3D;&quot;ms-PeoplePicker-searchBox&quot;&gt;
-    &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+    
     
     &lt;div class&#x3D;&quot;ms-TextField  ms-TextField--textFieldUnderlined &quot;&gt;
       
@@ -59,7 +59,7 @@ Presents the selected people in a list below the search field, rather than inlin
           Contacts
         &lt;/div&gt;
           &lt;div class&#x3D;&quot;ms-PeoplePicker-result &quot; tabindex&#x3D;&quot;1&quot;&gt;
-            &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+            
             
             &lt;div class&#x3D;&quot;ms-Persona
                   ms-Persona--sm
@@ -77,7 +77,7 @@ Presents the selected people in a list below the search field, rather than inlin
               &lt;button class&#x3D;&quot;ms-PeoplePicker-resultAction&quot;&gt;&lt;i class&#x3D;&quot;ms-Icon ms-Icon--Clear&quot;&gt;&lt;/i&gt;&lt;/button&gt;
           &lt;/div&gt;
           &lt;div class&#x3D;&quot;ms-PeoplePicker-result &quot; tabindex&#x3D;&quot;1&quot;&gt;
-            &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+            
             
             &lt;div class&#x3D;&quot;ms-Persona
                   ms-Persona--sm
@@ -95,7 +95,7 @@ Presents the selected people in a list below the search field, rather than inlin
               &lt;button class&#x3D;&quot;ms-PeoplePicker-resultAction&quot;&gt;&lt;i class&#x3D;&quot;ms-Icon ms-Icon--Clear&quot;&gt;&lt;/i&gt;&lt;/button&gt;
           &lt;/div&gt;
           &lt;div class&#x3D;&quot;ms-PeoplePicker-result &quot; tabindex&#x3D;&quot;1&quot;&gt;
-            &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+            
             
             &lt;div class&#x3D;&quot;ms-Persona
                   ms-Persona--sm
@@ -113,7 +113,7 @@ Presents the selected people in a list below the search field, rather than inlin
               &lt;button class&#x3D;&quot;ms-PeoplePicker-resultAction&quot;&gt;&lt;i class&#x3D;&quot;ms-Icon ms-Icon--Clear&quot;&gt;&lt;/i&gt;&lt;/button&gt;
           &lt;/div&gt;
           &lt;div class&#x3D;&quot;ms-PeoplePicker-result &quot; tabindex&#x3D;&quot;1&quot;&gt;
-            &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+            
             
             &lt;div class&#x3D;&quot;ms-Persona
                   ms-Persona--sm

--- a/ghdocs/components/Persona.md
+++ b/ghdocs/components/Persona.md
@@ -42,7 +42,7 @@ A persona can have one of seven presences: available, away, blocked, busy, do no
 
 <pre>
     <code>
- &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+ 
 
 &lt;div class&#x3D;&quot;ms-Persona
 &quot;&gt;

--- a/ghdocs/components/PersonaCard.md
+++ b/ghdocs/components/PersonaCard.md
@@ -22,10 +22,10 @@ The visualization of details of an individual including Skype contact details, e
 
 <pre>
     <code>
- &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+ 
 &lt;div class&#x3D;&quot;ms-PersonaCard &quot;&gt;
   &lt;div class&#x3D;&quot;ms-PersonaCard-persona&quot;&gt;
-    &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+    
     
     &lt;div class&#x3D;&quot;ms-Persona
           ms-Persona--lg
@@ -70,9 +70,9 @@ The visualization of details of an individual including Skype contact details, e
     &lt;div data-detail-id&#x3D;&quot;video&quot; class&#x3D;&quot;ms-PersonaCard-details&quot;&gt;
       &lt;div class&#x3D;&quot;ms-PersonaCard-detailLine&quot;&gt;&lt;span class&#x3D;&quot;ms-PersonaCard-detailLabel&quot;&gt;Skype:&lt;/span&gt; &lt;a class&#x3D;&quot;ms-Link&quot; href&#x3D;&quot;#&quot;&gt;Start Skype call&lt;/a&gt;&lt;/div&gt;
     &lt;/div&gt;
-      &lt;!-- org chart --&gt;
+      
     &lt;div data-detail-id&#x3D;&quot;org&quot; class&#x3D;&quot;ms-PersonaCard-details&quot;&gt;
-      &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+      
       
       &lt;div class&#x3D;&quot;ms-OrgChart &quot;&gt;
           &lt;div class&#x3D;&quot;ms-OrgChart-group&quot;&gt;
@@ -80,7 +80,7 @@ The visualization of details of an individual including Skype contact details, e
             &lt;ul class&#x3D;&quot;ms-OrgChart-list&quot;&gt;
                 &lt;li class&#x3D;&quot;ms-OrgChart-listItem&quot;&gt;
                   &lt;button class&#x3D;&quot;ms-OrgChart-listItemBtn&quot; tabindex&#x3D;&quot;1&quot;&gt;
-                    &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+                    
       
       &lt;div class&#x3D;&quot;ms-Persona
       &quot;&gt;
@@ -101,7 +101,7 @@ The visualization of details of an individual including Skype contact details, e
                 &lt;/li&gt;
                 &lt;li class&#x3D;&quot;ms-OrgChart-listItem&quot;&gt;
                   &lt;button class&#x3D;&quot;ms-OrgChart-listItemBtn&quot; tabindex&#x3D;&quot;1&quot;&gt;
-                    &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+                    
       
       &lt;div class&#x3D;&quot;ms-Persona
       &quot;&gt;
@@ -127,7 +127,7 @@ The visualization of details of an individual including Skype contact details, e
             &lt;ul class&#x3D;&quot;ms-OrgChart-list&quot;&gt;
                 &lt;li class&#x3D;&quot;ms-OrgChart-listItem&quot;&gt;
                   &lt;button class&#x3D;&quot;ms-OrgChart-listItemBtn&quot; tabindex&#x3D;&quot;1&quot;&gt;
-                    &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+                    
       
       &lt;div class&#x3D;&quot;ms-Persona
       &quot;&gt;
@@ -153,7 +153,7 @@ The visualization of details of an individual including Skype contact details, e
             &lt;ul class&#x3D;&quot;ms-OrgChart-list&quot;&gt;
                 &lt;li class&#x3D;&quot;ms-OrgChart-listItem&quot;&gt;
                   &lt;button class&#x3D;&quot;ms-OrgChart-listItemBtn&quot; tabindex&#x3D;&quot;1&quot;&gt;
-                    &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+                    
       
       &lt;div class&#x3D;&quot;ms-Persona
       &quot;&gt;
@@ -174,7 +174,7 @@ The visualization of details of an individual including Skype contact details, e
                 &lt;/li&gt;
                 &lt;li class&#x3D;&quot;ms-OrgChart-listItem&quot;&gt;
                   &lt;button class&#x3D;&quot;ms-OrgChart-listItemBtn&quot; tabindex&#x3D;&quot;1&quot;&gt;
-                    &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+                    
       
       &lt;div class&#x3D;&quot;ms-Persona
       &quot;&gt;
@@ -195,7 +195,7 @@ The visualization of details of an individual including Skype contact details, e
                 &lt;/li&gt;
                 &lt;li class&#x3D;&quot;ms-OrgChart-listItem&quot;&gt;
                   &lt;button class&#x3D;&quot;ms-OrgChart-listItemBtn&quot; tabindex&#x3D;&quot;1&quot;&gt;
-                    &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+                    
       
       &lt;div class&#x3D;&quot;ms-Persona
       &quot;&gt;
@@ -216,7 +216,7 @@ The visualization of details of an individual including Skype contact details, e
                 &lt;/li&gt;
                 &lt;li class&#x3D;&quot;ms-OrgChart-listItem&quot;&gt;
                   &lt;button class&#x3D;&quot;ms-OrgChart-listItemBtn&quot; tabindex&#x3D;&quot;1&quot;&gt;
-                    &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+                    
       
       &lt;div class&#x3D;&quot;ms-Persona
       &quot;&gt;

--- a/ghdocs/components/Pivot.md
+++ b/ghdocs/components/Pivot.md
@@ -40,7 +40,7 @@ A layout component that allows a user to switch between different sets of conten
 
 <pre>
     <code>
- &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+ 
 
 &lt;div class&#x3D;&quot;ms-Pivot &quot;&gt;
   &lt;ul class&#x3D;&quot;ms-Pivot-links&quot;&gt;

--- a/ghdocs/components/ProgressIndicator.md
+++ b/ghdocs/components/ProgressIndicator.md
@@ -22,7 +22,7 @@ Displays the progress of an operation when the percentage complete can be determ
 
 <pre>
     <code>
- &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+ 
 
 &lt;div class&#x3D;&quot;ms-ProgressIndicator&quot;&gt;
   &lt;div class&#x3D;&quot;ms-ProgressIndicator-itemName&quot;&gt;&lt;/div&gt;

--- a/ghdocs/components/SearchBox.md
+++ b/ghdocs/components/SearchBox.md
@@ -20,30 +20,6 @@ A special form field that allows for the input of search text.
 
 ### Command bar
 
-<!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. -->
-
-<div class="ms-SearchBox  ms-SearchBox--commandBar  ">
-  <input class="ms-SearchBox-field" type="text" value="">
-  <label class="ms-SearchBox-label">
-    <i class="ms-SearchBox-icon ms-Icon ms-Icon--Search"></i>
-    <span class="ms-SearchBox-text">Search</span>
-  </label>
-  <!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. -->
-<div class="ms-CommandButton ms-SearchBox-clear ms-CommandButton--noLabel  ">
-  <button class="ms-CommandButton-button"  >
-      <span class="ms-CommandButton-icon "><i class="ms-Icon ms-Icon--Clear"></i></span><span class="ms-CommandButton-label"></span>  </button>
-</div>
-  <!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. -->
-<div class="ms-CommandButton ms-SearchBox-exit ms-CommandButton--noLabel  ">
-  <button class="ms-CommandButton-button"  >
-      <span class="ms-CommandButton-icon "><i class="ms-Icon ms-Icon--ChromeBack"></i></span><span class="ms-CommandButton-label"></span>  </button>
-</div>
-  <!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. -->
-<div class="ms-CommandButton ms-SearchBox-filter ms-CommandButton--noLabel  ">
-  <button class="ms-CommandButton-button"  >
-      <span class="ms-CommandButton-icon "><i class="ms-Icon ms-Icon--Filter"></i></span><span class="ms-CommandButton-label"></span>  </button>
-</div>
-</div>
 
 ![SearchBox example](https://raw.githubusercontent.com/OfficeDev/office-ui-fabric-js/master/ghdocs/component_images/SearchBox-collapsed.png)
 

--- a/ghdocs/components/SearchBox.md
+++ b/ghdocs/components/SearchBox.md
@@ -20,6 +20,7 @@ A special form field that allows for the input of search text.
 
 ### Command bar
 
+<!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. -->
 
 <div class="ms-SearchBox  ms-SearchBox--commandBar  ">
   <input class="ms-SearchBox-field" type="text" value="">
@@ -27,15 +28,18 @@ A special form field that allows for the input of search text.
     <i class="ms-SearchBox-icon ms-Icon ms-Icon--Search"></i>
     <span class="ms-SearchBox-text">Search</span>
   </label>
-  <div class="ms-CommandButton ms-SearchBox-clear ms-CommandButton--noLabel  ">
+  <!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. -->
+<div class="ms-CommandButton ms-SearchBox-clear ms-CommandButton--noLabel  ">
   <button class="ms-CommandButton-button"  >
       <span class="ms-CommandButton-icon "><i class="ms-Icon ms-Icon--Clear"></i></span><span class="ms-CommandButton-label"></span>  </button>
 </div>
-  <div class="ms-CommandButton ms-SearchBox-exit ms-CommandButton--noLabel  ">
+  <!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. -->
+<div class="ms-CommandButton ms-SearchBox-exit ms-CommandButton--noLabel  ">
   <button class="ms-CommandButton-button"  >
       <span class="ms-CommandButton-icon "><i class="ms-Icon ms-Icon--ChromeBack"></i></span><span class="ms-CommandButton-label"></span>  </button>
 </div>
-  <div class="ms-CommandButton ms-SearchBox-filter ms-CommandButton--noLabel  ">
+  <!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. -->
+<div class="ms-CommandButton ms-SearchBox-filter ms-CommandButton--noLabel  ">
   <button class="ms-CommandButton-button"  >
       <span class="ms-CommandButton-icon "><i class="ms-Icon ms-Icon--Filter"></i></span><span class="ms-CommandButton-label"></span>  </button>
 </div>
@@ -57,7 +61,7 @@ A special form field that allows for the input of search text.
 
 <pre>
     <code>
- &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+ 
 
 &lt;div class&#x3D;&quot;ms-SearchBox  &quot;&gt;
   &lt;input class&#x3D;&quot;ms-SearchBox-field&quot; type&#x3D;&quot;text&quot; value&#x3D;&quot;&quot;&gt;
@@ -65,7 +69,7 @@ A special form field that allows for the input of search text.
     &lt;i class&#x3D;&quot;ms-SearchBox-icon ms-Icon ms-Icon--Search&quot;&gt;&lt;/i&gt;
     &lt;span class&#x3D;&quot;ms-SearchBox-text&quot;&gt;Search&lt;/span&gt;
   &lt;/label&gt;
-  &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+  
 &lt;div class&#x3D;&quot;ms-CommandButton ms-SearchBox-clear ms-CommandButton--noLabel  &quot;&gt;
   &lt;button class&#x3D;&quot;ms-CommandButton-button&quot;  &gt;
       &lt;span class&#x3D;&quot;ms-CommandButton-icon &quot;&gt;&lt;i class&#x3D;&quot;ms-Icon ms-Icon--Clear&quot;&gt;&lt;/i&gt;&lt;/span&gt;&lt;span class&#x3D;&quot;ms-CommandButton-label&quot;&gt;&lt;/span&gt;  &lt;/button&gt;

--- a/ghdocs/components/Spinner.md
+++ b/ghdocs/components/Spinner.md
@@ -40,7 +40,7 @@ Displays the progress of an operation when the percentage complete can not be de
 
 <pre>
     <code>
- &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+ 
 
 &lt;div class&#x3D;&quot;ms-Spinner &quot;&gt;
 &lt;/div&gt;

--- a/ghdocs/components/Table.md
+++ b/ghdocs/components/Table.md
@@ -37,7 +37,7 @@ Rows can be selected.
 
 <pre>
     <code>
- &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+ 
 
 &lt;table class&#x3D;&quot;ms-Table &quot;&gt;
   &lt;thead&gt;

--- a/ghdocs/components/TextField.md
+++ b/ghdocs/components/TextField.md
@@ -48,7 +48,7 @@ Allows for the input of text. Can be a single line or multiple lines. Typically 
 
 <pre>
     <code>
- &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+ 
 
 &lt;div class&#x3D;&quot;ms-TextField  &quot;&gt;
   &lt;label class&#x3D;&quot;ms-Label&quot;&gt;Name&lt;/label&gt;

--- a/ghdocs/components/Toggle.md
+++ b/ghdocs/components/Toggle.md
@@ -34,7 +34,7 @@ Allows for turning on or off a setting. This is best suited for simple, singular
 
 <pre>
     <code>
- &lt;!-- Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information. --&gt;
+ 
 
 &lt;div class&#x3D;&quot;ms-Toggle  &quot;&gt;
   &lt;span class&#x3D;&quot;ms-Toggle-description&quot;&gt;Let apps use my location&lt;/span&gt;

--- a/src/documentation/pages/MessageBar/MessageBar.md
+++ b/src/documentation/pages/MessageBar/MessageBar.md
@@ -55,9 +55,9 @@ i--->
 ### Success
 Use sparingly when there's an exceptional need to tell the use that something went right. The preferred way to show success is to show, not tell (e.g. by navigating to show the result of the user action and letting users continue working on it or elsewhere).
 
-<!---
+<!----
 {{> MessageBar props=MessageBarExampleProps.success }}
---->
+---->
 <!---i
 ![MessageBar example](https://raw.githubusercontent.com/OfficeDev/office-ui-fabric-js/master/ghdocs/component_images/MessageBar-success.png)
 i--->

--- a/src/documentation/pages/SearchBox/SearchBox.md
+++ b/src/documentation/pages/SearchBox/SearchBox.md
@@ -23,9 +23,9 @@ i--->
 
 
 ### Command bar
-<!---
+<!----
 {{> SearchBox props=SearchBoxExampleProps.commandBar}}
---->
+---->
 <!---i
 ![SearchBox example](https://raw.githubusercontent.com/OfficeDev/office-ui-fabric-js/master/ghdocs/component_images/SearchBox-collapsed.png)
 i--->


### PR DESCRIPTION
This PR updates the `ghdocs` folder to match the contents after a build. Most of the differences are in removing the copyright notices from the sample code. The logic for this was added in a [previous PR](https://github.com/OfficeDev/office-ui-fabric-js/pull/91), but the resulting Markdown files weren't checked in at that time.