### PR TITLE
Change dialog position from absolute to fixed

### DIFF
--- a/src/components/Dialog/Dialog.scss
+++ b/src/components/Dialog/Dialog.scss
@@ -15,7 +15,7 @@
   max-width: 340px;
   padding: 28px 24px;
   z-index: $ms-zIndex-front;
-  position: absolute;
+  position: fixed;
   transform: translate(-50%, -50%);
   left: 50%;
   top: 50%;


### PR DESCRIPTION
Issue #107

Change position from absolute to fixed to prevent dialog from being cut off if page is scrolled

**Before**: 
![screen shot 2016-09-06 at 4 40 13 pm](https://cloud.githubusercontent.com/assets/1291968/18294781/a67f3f98-7450-11e6-985f-956e320c199a.png)

**After**:
![screen shot 2016-09-06 at 4 40 18 pm](https://cloud.githubusercontent.com/assets/1291968/18294782/a860a1e4-7450-11e6-8268-59e9d43039f9.png)