### PR TITLE
Ensure that text box gets focus when the placeholder text is clicked.

### DIFF
--- a/src/components/TextField/TextField.ts
+++ b/src/components/TextField/TextField.ts
@@ -54,6 +54,10 @@ namespace fabric {
         this._textField.addEventListener("focus", (event: MouseEvent) => {
           this._textFieldLabel.style.display = "none";
         });
+		// Ensure that the text box gets focus when the placeholder text itself is clicked.
+        this._textFieldLabel.addEventListener("click", (event: MouseEvent) => {
+          this._textField.focus();
+        });
         this._textField.addEventListener("blur", (event: MouseEvent) => {
           // Show only if no value in the text field
           if (this._textField.value.length === 0) {


### PR DESCRIPTION
Without this change, the user has to click to the right of the placeholder text in order to give the text box focus and enter something in it. If user clicks on the part of the text box with the placeholder text, nothing happens; the text box appears to be broken.

This fixes #142 