### PR TITLE
Fix Error: (TypeError: item is undefined) in FireFox

### DIFF
--- a/src/components/Dropdown/Dropdown.ts
+++ b/src/components/Dropdown/Dropdown.ts
@@ -185,7 +185,7 @@ namespace fabric {
     }
 
     private _onItemSelection(evt: any) {
-      let item = <HTMLLIElement>evt.srcElement;
+      let item = <HTMLLIElement>evt.target;
       let isDropdownDisabled = this._container.classList.contains(IS_DISABLED_CLASS);
       let isOptionDisabled = item.classList.contains(IS_DISABLED_CLASS);
       if (!isDropdownDisabled && !isOptionDisabled) {


### PR DESCRIPTION
this commit fixes #148
Fix Error: (TypeError: item is undefined) in FireFox by changing from evc.srcElement to Event.target Property 