### PR TITLE
Fix TypeError: this._container.parentNode is null in ContextualHost

### DIFF
--- a/src/components/Callout/Callout.ts
+++ b/src/components/Callout/Callout.ts
@@ -40,7 +40,6 @@ namespace fabric {
     }
 
     private _openContextMenu() {
-
       let modifiers = [];
       if (this._hasModifier(MODIFIER_OOBE_CLASS)) {
         modifiers.push("primaryArrow");
@@ -66,6 +65,8 @@ namespace fabric {
 
     private _closeHandler(e) {
       this._contextualHost.disposeModal();
+      this._closeButton.removeEventListener("click", this._closeHandler.bind(this), false);
+      this._addTarget.removeEventListener("click", this._clickHandler.bind(this), true);
     }
 
     private _clickHandler(e) {

--- a/src/components/ContextualHost/ContextualHost.ts
+++ b/src/components/ContextualHost/ContextualHost.ts
@@ -384,7 +384,6 @@ namespace fabric {
 
     private _setDismissClick() {
       document.addEventListener("click", this._dismissAction, true);
-      // document.addEventListener("focus", this._dismissAction, true);
       document.addEventListener("keyup", (e: KeyboardEvent) => {
         if (e.keyCode === 32 || e.keyCode === 27) {
           this._dismissAction(e);

--- a/src/components/ContextualHost/ContextualHost.ts
+++ b/src/components/ContextualHost/ContextualHost.ts
@@ -384,7 +384,7 @@ namespace fabric {
 
     private _setDismissClick() {
       document.addEventListener("click", this._dismissAction, true);
-      document.addEventListener("focus", this._dismissAction, true);
+      // document.addEventListener("focus", this._dismissAction, true);
       document.addEventListener("keyup", (e: KeyboardEvent) => {
         if (e.keyCode === 32 || e.keyCode === 27) {
           this._dismissAction(e);


### PR DESCRIPTION
Fixes Issue #153. 

- Removed event handlers in Callout.ts once the component is dismissed.
- Removed Document.focus event handler in ContextualHost.  This was firing off the dismissAction method twice, which causes the error.