### PR TITLE
Fix for the datepicker event target in IE and Edge

### DIFF
--- a/src/components/DatePicker/Jquery.DatePicker.ts
+++ b/src/components/DatePicker/Jquery.DatePicker.ts
@@ -173,7 +173,7 @@ namespace fabric {
       $monthPicker.on("click", ".js-changeDate", (event) => {
         event.preventDefault();
 
-        let $changeDate = $(event.toElement);
+        let $changeDate = $(event.target);
 
         /** Get the requested date from the data attributes. */
         let newYear = $changeDate.attr("data-year");
@@ -192,7 +192,7 @@ namespace fabric {
       /** Change the highlighted year. */
       $yearPicker.on("click", ".js-changeDate", (event) => {
         event.preventDefault();
-        let $changeDate = $(event.toElement);
+        let $changeDate = $(event.target);
 
         /** Get the requested date from the data attributes. */
         let newYear = $changeDate.attr("data-year");


### PR DESCRIPTION
replaces ` event.toElement ` with `event.target` to fix the datepicker in IE and Edge.

Fixes #159 