### PR TITLE
Fix textfield focus

### DIFF
--- a/src/components/TextField/TextField.ts
+++ b/src/components/TextField/TextField.ts
@@ -49,14 +49,14 @@ namespace fabric {
 
     /** Add event listeners according to the type(s) of text field */
     private _addListeners(): void {
+      // Ensure that the text box gets focus when the label is clicked.
+      this._textFieldLabel.addEventListener("click", (event: MouseEvent) => {
+        this._textField.focus();
+      });
       /** Placeholder - hide/unhide the placeholder  */
       if (this._type.indexOf(TextFieldConsts.Type.Placeholder) >= 0) {
         this._textField.addEventListener("focus", (event: MouseEvent) => {
           this._textFieldLabel.style.display = "none";
-        });
-		// Ensure that the text box gets focus when the placeholder text itself is clicked.
-        this._textFieldLabel.addEventListener("click", (event: MouseEvent) => {
-          this._textField.focus();
         });
         this._textField.addEventListener("blur", (event: MouseEvent) => {
           // Show only if no value in the text field


### PR DESCRIPTION
Fix #142.

Couldn't repo the bug 100%, but I thought adding this as a catch-all for all textfields regardless of placeholders or not would work.