### PR TITLE
Support the last 3 major versions of all browsers with Autoprefixer

### DIFF
--- a/gulp/Documentation.js
+++ b/gulp/Documentation.js
@@ -213,7 +213,7 @@ gulp.task('Documentation-buildStyles', function () {
             .pipe(Plugins.rename('demo.css'))
             .pipe(Plugins.changed(Config.paths.distDocumentationCSS, {extension: '.css'}))
             .pipe(Plugins.autoprefixer({
-              browsers: ['last 2 versions', 'ie >= 9'],
+              browsers: ['last 3 versions', 'ie >= 9'],
               cascade: false
             }))
             .pipe(Plugins.cssbeautify())

--- a/gulp/FabricComponents.js
+++ b/gulp/FabricComponents.js
@@ -88,7 +88,7 @@ gulp.task('FabricComponents-buildAndCombineStyles', function () {
         })))
         .pipe(Plugins.autoprefixer(
             {
-                browsers: ['last 2 versions', 'ie >= 9'],
+                browsers: ['last 3 versions', 'ie >= 9'],
                 cascade: false
             }
         ))

--- a/gulp/SamplesBuild.js
+++ b/gulp/SamplesBuild.js
@@ -49,7 +49,7 @@ gulp.task('Samples-buildStyles',  function () {
                 .pipe(BuildConfig.processorPlugin().on('error', BuildConfig.compileErrorHandler))
                     .on('error', ErrorHandling.onErrorInPipe)
                 .pipe(Plugins.autoprefixer({
-                    browsers: ['last 2 versions', 'ie >= 9'],
+                    browsers: ['last 3 versions', 'ie >= 9'],
                     cascade: false
                 }))
                 .pipe(Plugins.rename(folder + '.css'))

--- a/gulp/modules/ComponentHelper.js
+++ b/gulp/modules/ComponentHelper.js
@@ -36,7 +36,7 @@ var ComponentSamplesHelper = function() {
             .pipe(Plugins.gulpif(outputSass, gulp.dest(destFolder)))
             .pipe(processorPlugin().on('error', errorHandler))
             .pipe(Plugins.autoprefixer({
-              browsers: ['last 2 versions', 'ie >= 9'],
+              browsers: ['last 3 versions', 'ie >= 9'],
               cascade: false
             }))
             .pipe(Plugins.rename(componentName + '.css'))


### PR DESCRIPTION
Fixes #177 

This PR updates the Autoprefixer config to add prefixes for the last three major versions of all browsers.