### PR TITLE
Fix datepicker method changeHighlightedClass, expose picker API to user

### DIFF
--- a/src/components/DatePicker/Jquery.DatePicker.ts
+++ b/src/components/DatePicker/Jquery.DatePicker.ts
@@ -10,6 +10,7 @@ namespace fabric {
    * DatePicker Plugin
    */
   export class DatePicker {
+    private picker: any;
 
     constructor(container, options) {
       /** Set up letiables and run the Pickadate plugin. */
@@ -72,7 +73,7 @@ namespace fabric {
         }
       }, options || {}));
       let $picker = $dateField.pickadate("picker");
-
+      this.picker = $picker;
       /** Respond to built-in picker events. */
       $picker.on({
         render: () => {
@@ -118,42 +119,42 @@ namespace fabric {
       $monthControls.on("click", ".js-prevMonth", (event) => {
         event.preventDefault();
         let newMonth = $picker.get("highlight").month - 1;
-        this.changeHighlightedDate($picker, null, newMonth, null);
+        this.changeHighlightedDate(null, newMonth, null);
       });
 
       /** Move ahead one month. */
       $monthControls.on("click", ".js-nextMonth", (event) => {
         event.preventDefault();
         let newMonth = $picker.get("highlight").month + 1;
-        this.changeHighlightedDate($picker, null, newMonth, null);
+        this.changeHighlightedDate(null, newMonth, null);
       });
 
       /** Move back one year. */
       $monthPicker.on("click", ".js-prevYear", (event) => {
         event.preventDefault();
         let newYear = $picker.get("highlight").year - 1;
-        this.changeHighlightedDate($picker, newYear, null, null);
+        this.changeHighlightedDate(newYear, null, null);
       });
 
       /** Move ahead one year. */
       $monthPicker.on("click", ".js-nextYear", (event) => {
         event.preventDefault();
         let newYear = $picker.get("highlight").year + 1;
-        this.changeHighlightedDate($picker, newYear, null, null);
+        this.changeHighlightedDate(newYear, null, null);
       });
 
       /** Move back one decade. */
       $yearPicker.on("click", ".js-prevDecade", (event) => {
         event.preventDefault();
         let newYear = $picker.get("highlight").year - 10;
-        this.changeHighlightedDate($picker, newYear, null, null);
+        this.changeHighlightedDate(newYear, null, null);
       });
 
       /** Move ahead one decade. */
       $yearPicker.on("click", ".js-nextDecade", (event) => {
         event.preventDefault();
         let newYear = $picker.get("highlight").year + 10;
-        this.changeHighlightedDate($picker, newYear, null, null);
+        this.changeHighlightedDate(newYear, null, null);
       });
 
       /** Go to the current date, shown in the day picking view. */
@@ -181,7 +182,7 @@ namespace fabric {
         let newDay = $changeDate.attr("data-day");
 
         /** Update the date. */
-        this.changeHighlightedDate($picker, newYear, newMonth, newDay);
+        this.changeHighlightedDate(newYear, newMonth, newDay);
 
         /** If we"ve been in the "picking months" state on mobile, remove that state so we show the calendar again. */
         if ($datePicker.hasClass("is-pickingMonths")) {
@@ -200,7 +201,7 @@ namespace fabric {
         let newDay = $changeDate.attr("data-day");
 
         /** Update the date. */
-        this.changeHighlightedDate($picker, newYear, newMonth, newDay);
+        this.changeHighlightedDate(newYear, newMonth, newDay);
 
         /** If we"ve been in the "picking years" state on mobile, remove that state so we show the calendar again. */
         if ($datePicker.hasClass("is-pickingYears")) {
@@ -226,21 +227,19 @@ namespace fabric {
     }
 
     /** Change the highlighted date. */
-    public changeHighlightedDate($picker, newYear, newMonth, newDay) {
-
-      /** All letiables are optional. If not provided, default to the current value. */
-      if (typeof newYear === "undefined" || newYear === null) {
-        newYear = $picker.get("highlight").year;
-      }
-      if (typeof newMonth === "undefined" || newMonth === null) {
-        newMonth = $picker.get("highlight").month;
-      }
-      if (typeof newDay === "undefined" || newDay === null) {
-        newDay = $picker.get("highlight").date;
-      }
+    public changeHighlightedDate(newYear, newMonth, newDay) {
+      let dateArr = this.setDateAttributes(newYear, newMonth, newDay);
 
       /** Update it. */
-      $picker.set("highlight", [newYear, newMonth, newDay]);
+      this.picker.set("highlight", dateArr);
+    }
+
+        /** Change the highlighted date. */
+    public changeSelectedDate(newYear, newMonth, newDay) {
+      let dateArr = this.setDateAttributes(newYear, newMonth, newDay);
+      
+      /** Update it. */
+      this.picker.set("select", dateArr);
     }
 
 
@@ -288,6 +287,20 @@ namespace fabric {
       $("html, body").animate({
         scrollTop: $datePicker.offset().top
       }, 367);
+    }
+
+    private setDateAttributes(newYear: any, newMonth: any, newDay: any): any[] {
+      /** All letiables are optional. If not provided, default to the current value. */
+      if (typeof newYear === "undefined" || newYear === null) {
+        newYear = this.picker.get("highlight").year;
+      }
+      if (typeof newMonth === "undefined" || newMonth === null) {
+        newMonth = this.picker.get("highlight").month;
+      }
+      if (typeof newDay === "undefined" || newDay === null) {
+        newDay = this.picker.get("highlight").date;
+      }
+      return [newYear, newMonth, newDay];
     }
   }
 }

--- a/src/components/DatePicker/Jquery.DatePicker.ts
+++ b/src/components/DatePicker/Jquery.DatePicker.ts
@@ -119,42 +119,42 @@ namespace fabric {
       $monthControls.on("click", ".js-prevMonth", (event) => {
         event.preventDefault();
         let newMonth = $picker.get("highlight").month - 1;
-        this.changeHighlightedDate(null, newMonth, null);
+        this.changeHighlightedDate([null, newMonth, null]);
       });
 
       /** Move ahead one month. */
       $monthControls.on("click", ".js-nextMonth", (event) => {
         event.preventDefault();
         let newMonth = $picker.get("highlight").month + 1;
-        this.changeHighlightedDate(null, newMonth, null);
+        this.changeHighlightedDate([null, newMonth, null]);
       });
 
       /** Move back one year. */
       $monthPicker.on("click", ".js-prevYear", (event) => {
         event.preventDefault();
         let newYear = $picker.get("highlight").year - 1;
-        this.changeHighlightedDate(newYear, null, null);
+        this.changeHighlightedDate([newYear, null, null]);
       });
 
       /** Move ahead one year. */
       $monthPicker.on("click", ".js-nextYear", (event) => {
         event.preventDefault();
         let newYear = $picker.get("highlight").year + 1;
-        this.changeHighlightedDate(newYear, null, null);
+        this.changeHighlightedDate([newYear, null, null]);
       });
 
       /** Move back one decade. */
       $yearPicker.on("click", ".js-prevDecade", (event) => {
         event.preventDefault();
         let newYear = $picker.get("highlight").year - 10;
-        this.changeHighlightedDate(newYear, null, null);
+        this.changeHighlightedDate([newYear, null, null]);
       });
 
       /** Move ahead one decade. */
       $yearPicker.on("click", ".js-nextDecade", (event) => {
         event.preventDefault();
         let newYear = $picker.get("highlight").year + 10;
-        this.changeHighlightedDate(newYear, null, null);
+        this.changeHighlightedDate([newYear, null, null]);
       });
 
       /** Go to the current date, shown in the day picking view. */
@@ -182,7 +182,7 @@ namespace fabric {
         let newDay = $changeDate.attr("data-day");
 
         /** Update the date. */
-        this.changeHighlightedDate(newYear, newMonth, newDay);
+        this.changeHighlightedDate([newYear, newMonth, newDay]);
 
         /** If we"ve been in the "picking months" state on mobile, remove that state so we show the calendar again. */
         if ($datePicker.hasClass("is-pickingMonths")) {
@@ -201,7 +201,7 @@ namespace fabric {
         let newDay = $changeDate.attr("data-day");
 
         /** Update the date. */
-        this.changeHighlightedDate(newYear, newMonth, newDay);
+        this.changeHighlightedDate([newYear, newMonth, newDay]);
 
         /** If we"ve been in the "picking years" state on mobile, remove that state so we show the calendar again. */
         if ($datePicker.hasClass("is-pickingYears")) {
@@ -227,22 +227,13 @@ namespace fabric {
     }
 
     /** Change the highlighted date. */
-    public changeHighlightedDate(newYear, newMonth, newDay) {
-      let dateArr = this.setDateAttributes(newYear, newMonth, newDay);
+    public changeHighlightedDate(dateArr) {
+      let newDateArr = this.setDateAttributes(dateArr);
 
       /** Update it. */
-      this.picker.set("highlight", dateArr);
+      this.picker.set("highlight", newDateArr);
     }
-
-        /** Change the highlighted date. */
-    public changeSelectedDate(newYear, newMonth, newDay) {
-      let dateArr = this.setDateAttributes(newYear, newMonth, newDay);
-      
-      /** Update it. */
-      this.picker.set("select", dateArr);
-    }
-
-
+    
     /** Whenever the picker renders, do our own rendering on the custom controls. */
     public updateCustomView($datePicker) {
 
@@ -289,7 +280,11 @@ namespace fabric {
       }, 367);
     }
 
-    private setDateAttributes(newYear: any, newMonth: any, newDay: any): any[] {
+    private setDateAttributes(dateArr: any): any[] {
+      let newYear = dateArr[0],
+          newMonth = dateArr[1],
+          newDay = dateArr[2];
+
       /** All letiables are optional. If not provided, default to the current value. */
       if (typeof newYear === "undefined" || newYear === null) {
         newYear = this.picker.get("highlight").year;

--- a/src/components/DatePicker/Jquery.DatePicker.ts
+++ b/src/components/DatePicker/Jquery.DatePicker.ts
@@ -233,7 +233,7 @@ namespace fabric {
       /** Update it. */
       this.picker.set("highlight", newDateArr);
     }
-    
+
     /** Whenever the picker renders, do our own rendering on the custom controls. */
     public updateCustomView($datePicker) {
 


### PR DESCRIPTION
Fixes issue #183 

- Adds picker to component so user can utilize pickadate API methods
- Remove picker parameter from changeHighlightedClass
- change changeHighlightedClass to use array as a parameter to be consistent with pickadate API

Users can use API methods like so:
```
datepicker = new fabric['DatePicker']('.ms-Datepicker');
// Change selected date
datepicker.picker.set('select', [2012, 0, 1]);

// Change highlighted date
datepicker.picker.set('highlight', [2015, 3, 20])
```