### PR TITLE
Fix multiple dropdown, fix double dismiss bug with panel dropdown

### DIFF
--- a/src/components/Dropdown/Dropdown.ts
+++ b/src/components/Dropdown/Dropdown.ts
@@ -170,7 +170,7 @@ namespace fabric {
       if (!isDisabled && !isOpen) {
         /** Stop the click event from propagating, which would just close the dropdown immediately. */
         evt.stopPropagation();
-        this.closeOtherDropdowns();
+        this._closeOtherDropdowns();
 
         /** Go ahead and open that dropdown. */
         this._container.classList.add(IS_OPEN_CLASS);
@@ -185,7 +185,7 @@ namespace fabric {
       }
     }
 
-    private closeOtherDropdowns() {
+    private _closeOtherDropdowns() {
       let dropdowns = document.querySelectorAll(`.${DROPDOWN_CLASS}.${IS_OPEN_CLASS}`);
       for (let i = 0; i < dropdowns.length; i++) {
         dropdowns[i].classList.remove(IS_OPEN_CLASS);

--- a/src/components/Dropdown/Dropdown.ts
+++ b/src/components/Dropdown/Dropdown.ts
@@ -148,22 +148,29 @@ namespace fabric {
         this._panel = new fabric.Panel(this._panelContainer);
       }
     }
-    private _removeDropdownAsPanel() {
+    private _removeDropdownAsPanel(evt?: Event) {
       if (this._panel !== undefined) {
           /** destroy panel and move dropdown back to outside the panel */
-          this._panel.dismiss(() => {
+          /* if event target is overlay element, only append dropdown to prevent */
+          /* double dismiss bug, otherwise, dismiss and append */
+          if (evt && evt.target === this._panel._panelHost._overlay.overlayElement) {
             this._container.appendChild(this._newDropdown);
-          });
+          } else {
+            this._panel.dismiss(() => {
+              this._container.appendChild(this._newDropdown);
+            });
+          }
           this._panel = undefined;
         }
     }
 
-    private _onOpenDropdown(evt: any) {
+    private _onOpenDropdown(evt: Event) {
       let isDisabled = this._container.classList.contains(IS_DISABLED_CLASS);
       let isOpen = this._container.classList.contains(IS_OPEN_CLASS);
       if (!isDisabled && !isOpen) {
         /** Stop the click event from propagating, which would just close the dropdown immediately. */
         evt.stopPropagation();
+        this.closeOtherDropdowns();
 
         /** Go ahead and open that dropdown. */
         this._container.classList.add(IS_OPEN_CLASS);
@@ -178,8 +185,15 @@ namespace fabric {
       }
     }
 
-    private _onCloseDropdown() {
-      this._removeDropdownAsPanel();
+    private closeOtherDropdowns() {
+      let dropdowns = document.querySelectorAll(`.${DROPDOWN_CLASS}.${IS_OPEN_CLASS}`);
+      for (let i = 0; i < dropdowns.length; i++) {
+        dropdowns[i].classList.remove(IS_OPEN_CLASS);
+      }
+    }
+
+    private _onCloseDropdown(evt: Event) {
+      this._removeDropdownAsPanel(evt);
       this._container.classList.remove(IS_OPEN_CLASS);
       document.removeEventListener("click", this._onCloseDropdown);
     }

--- a/src/components/Dropdown/Dropdown.ts
+++ b/src/components/Dropdown/Dropdown.ts
@@ -153,7 +153,7 @@ namespace fabric {
           /** destroy panel and move dropdown back to outside the panel */
           /* if event target is overlay element, only append dropdown to prevent */
           /* double dismiss bug, otherwise, dismiss and append */
-          if (evt && evt.target === this._panel._panelHost._overlay.overlayElement) {
+          if (evt && evt.target === this._panel.panelHost.overlay.overlayElement) {
             this._container.appendChild(this._newDropdown);
           } else {
             this._panel.dismiss(() => {

--- a/src/components/Panel/Panel.ts
+++ b/src/components/Panel/Panel.ts
@@ -15,7 +15,7 @@ namespace fabric {
 
   export class Panel {
 
-    public _panelHost: PanelHost;
+    public panelHost: PanelHost;
     private _panel: Element;
     private _direction: string;
     private _animateOverlay: boolean;
@@ -31,7 +31,7 @@ namespace fabric {
       this._panel = panel;
       this._direction = direction || "right";
       this._animateOverlay = animateOverlay || true;
-      this._panelHost = new fabric.PanelHost(this._panel, this._animateInPanel);
+      this.panelHost = new fabric.PanelHost(this._panel, this._animateInPanel);
       this._closeButton = this._panel.querySelector(".ms-PanelAction-close");
       this._clickHandler = this.dismiss.bind(this, null);
       this._setEvents();
@@ -45,7 +45,7 @@ namespace fabric {
       setTimeout(() => {
         this._panel.classList.remove(ANIMATE_OUT_STATE);
         this._panel.classList.remove("is-open");
-        this._panelHost.dismiss();
+        this.panelHost.dismiss();
         if (callBack) {
           callBack();
         }
@@ -58,7 +58,7 @@ namespace fabric {
     }
 
     private _setEvents() {
-      this._panelHost._overlay.overlayElement.addEventListener("click", this._clickHandler);
+      this.panelHost.overlay.overlayElement.addEventListener("click", this._clickHandler);
       if (this._closeButton !== null) {
         this._closeButton.addEventListener("click", this._clickHandler);
       }

--- a/src/components/Panel/Panel.ts
+++ b/src/components/Panel/Panel.ts
@@ -15,8 +15,8 @@ namespace fabric {
 
   export class Panel {
 
+    public _panelHost: PanelHost;
     private _panel: Element;
-    private _panelHost: PanelHost;
     private _direction: string;
     private _animateOverlay: boolean;
     private _closeButton: Element;

--- a/src/components/PanelHost/PanelHost.ts
+++ b/src/components/PanelHost/PanelHost.ts
@@ -14,7 +14,7 @@ namespace fabric {
   export class PanelHost {
 
     public panelHost: Element;
-    public _overlay: Overlay;
+    public overlay: Overlay;
     private _layer: Node;
     private _callBack: Function;
     private _overlayContainer: HTMLElement;
@@ -32,7 +32,7 @@ namespace fabric {
     }
 
     public dismiss() {
-      this._overlay.hide();
+      this.overlay.hide();
       document.body.removeChild(this.panelHost);
     }
 
@@ -55,11 +55,11 @@ namespace fabric {
       this.panelHost = document.createElement("div");
       this.panelHost.classList.add(PANEL_HOST_CLASS);
       this.panelHost.appendChild(this._layer);
-      this._overlay = new fabric.Overlay(this._overlayContainer);
-      this._overlay.show();
+      this.overlay = new fabric.Overlay(this._overlayContainer);
+      this.overlay.show();
 
       // Append Elements
-      this.panelHost.appendChild(this._overlay.overlayElement);
+      this.panelHost.appendChild(this.overlay.overlayElement);
     }
   }
 }


### PR DESCRIPTION
Fixes #184 

- Dismisses other open dropdowns
- Fixes double dismiss bug with panel dropdown (if you click on the overlay with a panel dropdown, panelhost tries dismissing twice)