### PR TITLE
Fix ContextualHost position for left and top direction

### DIFF
--- a/src/components/ContextualHost/ContextualHost.scss
+++ b/src/components/ContextualHost/ContextualHost.scss
@@ -66,12 +66,14 @@
 
 .ms-ContextualHost.ms-ContextualHost--arrowTop {
   .ms-ContextualHost-beak {
+    display: block;
     top: -10px;
   }
 }
 
 .ms-ContextualHost.ms-ContextualHost--arrowBottom {
   .ms-ContextualHost-beak {
+    display: block;
     bottom: -10px;
   }
 }

--- a/src/components/ContextualHost/ContextualHost.ts
+++ b/src/components/ContextualHost/ContextualHost.ts
@@ -248,7 +248,7 @@ namespace fabric {
 
       switch (curDirection) {
         case "left":
-          mHLeft = (teLeft - this._modalWidth) + arrowSpace;
+          mHLeft = teLeft - this._modalWidth - arrowSpace;
           mHTop = this._calcTop(this._modalHeight, teHeight, teTop);
           mHTop += window.scrollY ? window.scrollY : 0;
           this._container.setAttribute("style", "top: " + mHTop + "px; left: " + mHLeft + "px;" + mWidth);
@@ -275,7 +275,7 @@ namespace fabric {
         break;
         case "top":
           mHLeft = this._calcLeft(this._modalWidth, this._teWidth, teLeft);
-          mHTop = (teTop - this._modalHeight) + arrowSpace;
+          mHTop = teTop - this._modalHeight - arrowSpace;
           mHTop += windowY;
           this._container.setAttribute("style", "top: " + mHTop + "px; left: " + mHLeft + "px;" + mWidth);
           this._container.classList.add(MODAL_STATE_POSITIONED);

--- a/src/components/ContextualHost/ContextualHost.ts
+++ b/src/components/ContextualHost/ContextualHost.ts
@@ -234,11 +234,14 @@ namespace fabric {
       let teLeft = teBR.left;
       let teRight = teBR.right;
       let teTop = teBR.top;
+      let teWidth = teBR.width;
       let teHeight = teBR.height;
       let mHLeft;
       let mHTop;
       let mWidth = "";
       let arrowTop;
+      let arrowLeft;
+      let windowX = window.scrollX ? window.scrollX : 0;
       let windowY = window.scrollY ? window.scrollY : 0;
       let arrowSpace = (this._hasArrow) ? ARROW_SIZE : 0;
 
@@ -281,6 +284,9 @@ namespace fabric {
           this._container.classList.add(MODAL_STATE_POSITIONED);
 
           if (this._hasArrow) {
+            arrowTop = this._modalHeight - (arrowSpace / 2);
+            arrowLeft = Math.max(windowX + teLeft - mHLeft + ((teWidth - arrowSpace) / 2), ARROW_OFFSET);
+            this._arrow.setAttribute("style", "top: " + arrowTop + "px; left: " + arrowLeft + "px;");
             this._container.classList.add(ARROW_BOTTOM_CLASS);
           }
         break;
@@ -292,6 +298,8 @@ namespace fabric {
           this._container.classList.add(MODAL_STATE_POSITIONED);
 
           if (this._hasArrow) {
+            arrowLeft = Math.max(windowX + teLeft - mHLeft + ((teWidth - arrowSpace) / 2), ARROW_OFFSET);
+            this._arrow.setAttribute("style", "left: " + arrowLeft + "px;");
             this._container.classList.add(ARROW_TOP_CLASS);
           }
         break;


### PR DESCRIPTION
When calculating the position of the ContextualHost for the left and top
direction, the space occupied by the beak (arrowSpace) should be
subtracted instead of added to prevent the host from overlapping with the
target element.

Before:  https://plnkr.co/pILtwivmCjY4rPc5dPLm
After:  https://plnkr.co/pjUlvxrVUjZTP6fYsQwG