### PR TITLE
Update the CDN references in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ If you'd like to get Fabric through a package manager such as Bower, npm, or NuG
 Include the following references in the `<head>` of your page:
 
 ```html
-<link rel="stylesheet" href="https://appsforoffice.microsoft.com/fabric/fabric-core/4.0.0/fabric.min.css">
-<link rel="stylesheet" href="https://appsforoffice.microsoft.com/fabric/fabric-js/1.0.0/fabric.components.min.css">
+<link rel="stylesheet" href="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-core/5.0.1/css/fabric.min.css">
+<link rel="stylesheet" href="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-js/1.2.0/css/fabric.components.min.css">
 ```
 
 **Note:** You may notice an additional reference to the Fabric Core - this is intentional as these styles are almost always needed for experiences where you'd like to use the components, so we recommend including it by default.


### PR DESCRIPTION
Updates the CDN references in the README to point to the new CDN location.

**Do not merge until [this file](https://static2.sharepointonline.com/files/fabric/office-ui-fabric-js/1.2.0/css/fabric.components.min.css) is available on the CDN.**