### PR TITLE
Update Fabric Core to 5.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,6 @@
     "walk-sync": "^0.2.6"
   },
   "dependencies": {
-    "office-ui-fabric-core": "4.0.0"
+    "office-ui-fabric-core": "5.0.1"
   }
 }


### PR DESCRIPTION
Fixes #174 

Updates to Fabric Core 5.0.1. Verified that none of the responsive mixins (e.g. `ms-u-mdPull2()`) are being used in this project, so there are no changes required to upgrade. Built and tested locally.