### PR TITLE
Updating chevron css classes for MessageBanner (Fixing #205)

### DIFF
--- a/src/components/MessageBanner/MessageBanner.ts
+++ b/src/components/MessageBanner/MessageBanner.ts
@@ -117,7 +117,7 @@ namespace fabric {
     private _expand(): void {
       let icon = this._chevronButton.querySelector(".ms-Icon");
       this._errorBanner.className += " is-expanded";
-      icon.className = "ms-Icon ms-Icon--ChevronUp";
+      icon.className = "ms-Icon ms-Icon--DoubleChevronUp";
     }
 
     /**
@@ -126,7 +126,7 @@ namespace fabric {
     private _collapse(): void {
       let icon = this._chevronButton.querySelector(".ms-Icon");
       this._errorBanner.className = "ms-MessageBanner";
-      icon.className = "ms-Icon ms-Icon--ChevronDown";
+      icon.className = "ms-Icon ms-Icon--DoubleChevronDown";
     }
 
     private _toggleExpansion(): void {

--- a/src/components/MessageBanner/MessageBanner.ts
+++ b/src/components/MessageBanner/MessageBanner.ts
@@ -117,7 +117,7 @@ namespace fabric {
     private _expand(): void {
       let icon = this._chevronButton.querySelector(".ms-Icon");
       this._errorBanner.className += " is-expanded";
-      icon.className = "ms-Icon ms-Icon--chevronsUp";
+      icon.className = "ms-Icon ms-Icon--ChevronUp";
     }
 
     /**
@@ -126,7 +126,7 @@ namespace fabric {
     private _collapse(): void {
       let icon = this._chevronButton.querySelector(".ms-Icon");
       this._errorBanner.className = "ms-MessageBanner";
-      icon.className = "ms-Icon ms-Icon--chevronsDown";
+      icon.className = "ms-Icon ms-Icon--ChevronDown";
     }
 
     private _toggleExpansion(): void {


### PR DESCRIPTION
In `MessageBanner.ts ` the chevron css class names are now correctly linked to the current set of icons from `fabric.css`
<img width="266" alt="chevrons_fabric css" src="https://cloud.githubusercontent.com/assets/23665008/20541973/bfe4d09c-b0ff-11e6-91c7-736a4a0fa0b2.png">
