### PR TITLE
Documentation updates for Get Started page and DatePicker

### DIFF
--- a/gulp/modules/Config.js
+++ b/gulp/modules/Config.js
@@ -188,6 +188,12 @@ var Config = function() {
           return code;
         },
 
+        cdnLinks: function(version) {
+          return `<link rel="stylesheet" href="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-js/${version}/css/fabric.min.css" />
+<link rel="stylesheet" href="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-js/${version}/css/fabric.components.min.css" />
+<script src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-js/${version}/js/fabric.min.js"></script>`;
+        },
+
         // Output code from a string
         codeBlock: function(code, language, theme) {
           var hbs = Plugins.handlebars.Handlebars;

--- a/src/documentation/pages/Components/DatePicker/DatePicker.js
+++ b/src/documentation/pages/Components/DatePicker/DatePicker.js
@@ -11,14 +11,24 @@ var data = {
   ],
   methods: [
     {
-      name: "changeHighlightedDate(dateArr)",
+      name: "picker.set('select', dateArr);",
       parameters: [
         {
           name: "dateArr",
           type: "{Array} The new date in [YEAR, MONTH, DATE] format", 
         }
       ],
-      description: "Highlights a new date in the component"
+      description: "Selects a new date in the component. Must be used on component's picker property  (DatePicker.picker)."
+    },
+    {
+      name: "picker.set('highlight', dateArr);",
+      parameters: [
+        {
+          name: "dateArr",
+          type: "{Array} The new date in [YEAR, MONTH, DATE] format", 
+        }
+      ],
+      description: "Highlights a new date in the component. Must be used on component's picker property (DatePicker.picker)."
     }
   ],
   jsFile: "DatePickerExampleJS",

--- a/src/documentation/pages/GetStarted/GetStarted.hbs
+++ b/src/documentation/pages/GetStarted/GetStarted.hbs
@@ -13,9 +13,7 @@
       <li>
         <p>The easiest way to get Fabric is by referencing the CDN. Include the following in the &lt;head&gt; of your page:</p>
         {{codeBlock 
-'<link rel="stylesheet" href="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-js/1.2.0/css/fabric.min.css" />
-<link rel="stylesheet" href="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-js/1.2.0/css/fabric.components.min.css" />
-<script src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-js/1.2.0/js/fabric.min.js"></script>' 'html' 'isLightTheme'}}
+(cdnLinks packageData.version) 'html' 'isLightTheme'}}
         <p>To reference the latest version, just change the version number in the URL to your desired version. All versions of Fabric are on the CDN, and the latest version is {{packageData.version}}.</p>
       </li>
       <li>

--- a/src/documentation/sass/SideBar.scss
+++ b/src/documentation/sass/SideBar.scss
@@ -105,6 +105,7 @@ $nav-group-header-height: 40px;
     &:hover {
       > a:first-child {
         color: $ms-color-neutralPrimary;
+        font-weight: $ms-font-weight-semibold;
       }
 
       // Hide the line indicators on submenus


### PR DESCRIPTION
Fixes Get Started page so version number in CDN links are pulled from package json
Fix DatePicker methods so it shows picker methods for select and highlight