### PR TITLE
Fix table selectable variant

### DIFF
--- a/src/components/Table/Table.ts
+++ b/src/components/Table/Table.ts
@@ -30,15 +30,16 @@ namespace fabric {
      */
     private _toggleRowSelection(event: MouseEvent): void {
       let selectedRow = (<HTMLElement>event.target).parentElement;
-      let selectedStateClass = "is-selected";
+      if (selectedRow.tagName === "TR") {
+        let selectedStateClass = "is-selected";
 
-      // Toggle the selected state class
-      if (selectedRow.className === selectedStateClass) {
-        selectedRow.className = "";
-      } else {
-        selectedRow.className = selectedStateClass;
+        // Toggle the selected state class
+        if (selectedRow.className === selectedStateClass) {
+          selectedRow.className = "";
+        } else {
+          selectedRow.className = selectedStateClass;
+        }
       }
-
     }
 
   }


### PR DESCRIPTION
Fixes #281.

Not sure if this is the most eloquent solution, but just added a check to see if the target element parent is a TR.  