### PR TITLE
Fix TypeError when event.target is HTMLDocument

### DIFF
--- a/src/components/ContextualMenu/ContextualMenu.ts
+++ b/src/components/ContextualMenu/ContextualMenu.ts
@@ -40,10 +40,12 @@ namespace fabric {
     }
 
     private _onDocumentClick(event: Event): void {
-      const target: HTMLElement = <HTMLElement>event.target;
-      const classList: DOMTokenList = target.classList;
-      if (!this._hostTarget.contains(target) && !classList.contains("ms-ContextualMenu-link")) {
-        this._isOpen = false;
+      if (event.target instanceof HTMLElement) {
+        const target: HTMLElement = <HTMLElement>event.target;
+        const classList: DOMTokenList = target.classList;
+        if (!this._hostTarget.contains(target) && !classList.contains("ms-ContextualMenu-link")) {
+          this._isOpen = false;
+        }
       }
     }
 


### PR DESCRIPTION
If you put a ContextualMenu and a DatePicker on the same page; and click inside the DatePicker; you get an unhandled TypeError.

ContextualMenu _onDocumentClick asserts event.target as HTMLElement. However, when you click in the DatePicker's textfield; the DatePicker will fire an event with the document object as a target. (Jquery.DatePicker.ts line 112)

Since the document object is an HTMLDocument, not an HTMLElement, classList ends up as undefined. Hence you get the TypeError when trying to access classList.contains.

Attachment: A minimal HTML page to reproduce the problem. (Rename the file extension)

[contextualmenu-datecontrol-bug.html.txt](https://github.com/OfficeDev/office-ui-fabric-js/files/899854/contextualmenu-datecontrol-bug.html.txt)


