### PR TITLE
keyboard handler added

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "colors": "^1.1.0",
     "del": "^1.2.1",
     "express": "^4.10.4",
-    "gulp": "^3.9.0",
+    "gulp": "^3.9.1",
     "gulp-autoprefixer": "^2.3.1",
     "gulp-batch": "^1.0.5",
     "gulp-changed": "^1.3.0",

--- a/src/components/Callout/Callout.ts
+++ b/src/components/Callout/Callout.ts
@@ -81,8 +81,7 @@ namespace fabric {
         event.stopPropagation();
         event.preventDefault();
         this._openContextMenu();
-      }
-      else {
+      } else {
         this._closeHandler(event);
       }
     }

--- a/src/components/Callout/Callout.ts
+++ b/src/components/Callout/Callout.ts
@@ -36,7 +36,7 @@ namespace fabric {
 
     private _setOpener() {
       this._addTarget.addEventListener("click", this._clickHandler.bind(this), true);
-      this._addTarget.addEventListener("keydown", this._keydownHandler.bind(this), true);
+      this._addTarget.addEventListener("keyup", this._keyupHandler.bind(this), true);
     }
 
     private _openContextMenu() {
@@ -56,7 +56,6 @@ namespace fabric {
 
       if (this._closeButton) {
         this._closeButton.addEventListener("click", this._closeHandler.bind(this), false);
-        this._closeButton.addEventListener("keydown", this._keydownHandler.bind(this), true);
       }
     }
 
@@ -65,18 +64,19 @@ namespace fabric {
     }
 
     private _closeHandler(e) {
-      this._contextualHost.disposeModal();
+      if (this._contextualHost != null) {
+        this._contextualHost.disposeModal();
+      }
       this._closeButton.removeEventListener("click", this._closeHandler.bind(this), false);
       this._addTarget.removeEventListener("click", this._clickHandler.bind(this), true);
-      this._closeButton.removeEventListener("keydown", this._keydownHandler.bind(this), false);
-      this._addTarget.removeEventListener("keydown", this._keydownHandler.bind(this), true);
+      this._addTarget.removeEventListener("keyup", this._keyupHandler.bind(this), true);
     }
 
     private _clickHandler(e) {
       this._openContextMenu();
     }
 
-    private _keydownHandler(event: KeyboardEvent): void {
+    private _keyupHandler(event: KeyboardEvent): void {
       if (event.keyCode === 32) {
         event.stopPropagation();
         event.preventDefault();

--- a/src/components/Callout/Callout.ts
+++ b/src/components/Callout/Callout.ts
@@ -36,6 +36,7 @@ namespace fabric {
 
     private _setOpener() {
       this._addTarget.addEventListener("click", this._clickHandler.bind(this), true);
+      this._addTarget.addEventListener("keydown", this._keydownHandler.bind(this), true);
     }
 
     private _openContextMenu() {
@@ -55,6 +56,7 @@ namespace fabric {
 
       if (this._closeButton) {
         this._closeButton.addEventListener("click", this._closeHandler.bind(this), false);
+        this._closeButton.addEventListener("keydown", this._keydownHandler.bind(this), true);
       }
     }
 
@@ -66,10 +68,24 @@ namespace fabric {
       this._contextualHost.disposeModal();
       this._closeButton.removeEventListener("click", this._closeHandler.bind(this), false);
       this._addTarget.removeEventListener("click", this._clickHandler.bind(this), true);
+      this._closeButton.removeEventListener("keydown", this._keydownHandler.bind(this), false);       
+      this._addTarget.removeEventListener("keydown", this._keydownHandler.bind(this), true);   
     }
 
     private _clickHandler(e) {
       this._openContextMenu();
     }
+
+    private _keydownHandler(event: KeyboardEvent): void {       
+      if (event.keyCode === 32) {         
+        event.stopPropagation();         
+        event.preventDefault();         
+        this._openContextMenu();       
+      }
+      else
+      {
+        this._closeHandler(event);
+      }
+    }   
   }
 }

--- a/src/components/Callout/Callout.ts
+++ b/src/components/Callout/Callout.ts
@@ -68,8 +68,8 @@ namespace fabric {
       this._contextualHost.disposeModal();
       this._closeButton.removeEventListener("click", this._closeHandler.bind(this), false);
       this._addTarget.removeEventListener("click", this._clickHandler.bind(this), true);
-      this._closeButton.removeEventListener("keydown", this._keydownHandler.bind(this), false);       
-      this._addTarget.removeEventListener("keydown", this._keydownHandler.bind(this), true);   
+      this._closeButton.removeEventListener("keydown", this._keydownHandler.bind(this), false);
+      this._addTarget.removeEventListener("keydown", this._keydownHandler.bind(this), true);
     }
 
     private _clickHandler(e) {
@@ -77,10 +77,10 @@ namespace fabric {
     }
 
     private _keydownHandler(event: KeyboardEvent): void {       
-      if (event.keyCode === 32) {         
-        event.stopPropagation();         
-        event.preventDefault();         
-        this._openContextMenu();       
+      if (event.keyCode === 32) {
+        event.stopPropagation();
+        event.preventDefault();
+        this._openContextMenu();
       }
       else
       {

--- a/src/components/Callout/Callout.ts
+++ b/src/components/Callout/Callout.ts
@@ -76,16 +76,15 @@ namespace fabric {
       this._openContextMenu();
     }
 
-    private _keydownHandler(event: KeyboardEvent): void {       
+    private _keydownHandler(event: KeyboardEvent): void {
       if (event.keyCode === 32) {
         event.stopPropagation();
         event.preventDefault();
         this._openContextMenu();
       }
-      else
-      {
+      else {
         this._closeHandler(event);
       }
-    }   
+    }
   }
 }


### PR DESCRIPTION
The current solution assumes that the component that triggers the CallOut is always a button. The button is not always a preferred component that triggers it because the Windows Narrator reads it as Button and the user might expect more than a help CallOut. This pull request adds the keyboard handler to the component that triggers irrespective of the type of the component.