### PR TITLE
Issue #364

### DIFF
--- a/src/components/PeoplePicker/PeoplePicker.ts
+++ b/src/components/PeoplePicker/PeoplePicker.ts
@@ -107,7 +107,7 @@ namespace fabric {
     }
 
     private _findElement(childObj: Element, className: string ) {
-      let currentElement: Element = <Element>childObj.parentNode;
+      let currentElement: Element = childObj;
 
       while (!currentElement.classList.contains(className)) {
           currentElement = <Element>currentElement.parentNode;


### PR DESCRIPTION
Bug Fix - The findElement method shouldn't skip the current element. Refer to [this issue](https://github.com/OfficeDev/office-ui-fabric-js/issues/364) for additional details.