### PR TITLE
Bug Fix - Null Exception

### DIFF
--- a/src/components/Overlay/Overlay.ts
+++ b/src/components/Overlay/Overlay.ts
@@ -17,7 +17,9 @@ namespace fabric {
     }
 
     public remove() {
-      this.overlayElement.parentElement.removeChild(this.overlayElement);
+      if(this.overlayElement.parentElement) {
+        this.overlayElement.parentElement.removeChild(this.overlayElement);
+      }
     }
 
     public show(): void {


### PR DESCRIPTION
The overlayElement is not added to the document by default, so the parentElement may be null.